### PR TITLE
Retrieve bitness from OMPI if not already set

### DIFF
--- a/lib/MTT/MPI/Install/Analyze/OMPI.pm
+++ b/lib/MTT/MPI/Install/Analyze/OMPI.pm
@@ -54,6 +54,11 @@ sub Install {
     $ret->{f90_bindings} = &{$func}($ret->{bindir}, $ret->{libdir}, "f90");
     Debug("Have F90 bindings: $ret->{f90_bindings}\n"); 
 
+    $func = \&MTT::Values::Functions::MPI::OMPI::find_bitness;
+    $config->{bitness} = &{$func}($ret->{bindir}, $ret->{libdir})
+        if (!defined($config->{bitness}));
+
+
     return $ret;
 }
 


### PR DESCRIPTION
bitness is now retrieved directly from OpenMPI via ompi_info if not already set.

this is an improvement if the AlreadyInstalled module is used (bitness would be undefined otherwise)
