### PR TITLE
hooks: add new hooks functionality to the mtt client

### DIFF
--- a/client/mtt
+++ b/client/mtt
@@ -106,6 +106,7 @@ use MTT::INI;
 use MTT::Reporter;
 use MTT::Defaults;
 use MTT::Globals;
+use MTT::Hooks;
 use MTT::FindProgram;
 use MTT::Trim;
 use MTT::DoCommand;
@@ -521,7 +522,10 @@ foreach my $hash (@ini_list) {
         next;
     }
 
-	
+    # Run the init hook, if it exists
+    MTT::Hooks::init($ini);
+    MTT::Hooks::invoke("mtt_hook_init");
+
     # Examine the [MTT] global defaults section.  We've already
     # determined the scratch_root, so pass it in so that it gets set
     # in the Globals hash.
@@ -649,6 +653,10 @@ foreach my $hash (@ini_list) {
         Verbose("Deleting fast scratch tree: $fast_scratch_arg\n");
         MTT::DoCommand::Cmd(1, "rm -rf $fast_scratch_arg");
     }
+
+    # Run the finalize hook, if it exists
+    MTT::Hooks::invoke("mtt_hook_finalize");
+    MTT::Hooks::finalize();
 }
 
 # That's it!

--- a/lib/MTT/Hooks.pm
+++ b/lib/MTT/Hooks.pm
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+package MTT::Hooks;
+
+use strict;
+
+use File::Basename;
+use Data::Dumper;
+use MTT::Values;
+use MTT::Messages;
+
+
+# Hook file that we loaded
+my $_file;
+my $_prefix;
+
+# These are the hooks that are allowed
+my @_hooks = qw/mtt_hook_init mtt_hook_finalize/;
+
+
+# Load the hooks file
+sub init {
+    my $ini = shift;
+
+    # If there is a hook .pm file to load, load it now.
+
+    $_file = MTT::Values::Value($ini, "MTT", "hook_file");
+    $_prefix = MTT::Values::Value($ini, "MTT", "hook_prefix");
+    if (defined($_file)) {
+        Error("hook_file defined without hook_prefix")
+            if (!defined($_prefix));
+
+        require $_file;
+    }
+}
+
+# Invoke a hook
+sub invoke {
+    my $hook = shift;
+
+    # Sanity check to ensure that this is a defined hook.
+    my $found = 0;
+    foreach my $h (@_hooks) {
+        $found = 1
+            if ($h eq $hook);
+    }
+    Error("Tried to invoke undefined hook $hook\n")
+        if (0 == $found);
+
+    # Ok, it's s defined hook.  If it exists, invoke it.
+    my $func = "$_prefix$hook";
+    if (defined(&{$func})) {
+        Verbose("*** Invoking hook $func\n");
+        eval("$func();");
+        return 1;
+    }
+
+    Verbose("*** No hook $func; skipping\n");
+    return 0;
+}
+
+# Close out a hook file
+sub finalize {
+    # Would be great if we could "un-require" the file here, but I
+    # don't see an obvious way to do that.  The only thing I can see
+    # to do is to "undef" the hook functions that might exist.
+
+    foreach my $h (@_hooks) {
+        undef &{"${_prefix}$h"};
+    }
+
+    $_file = undef;
+    $_prefix = undef;
+}
+
+1;


### PR DESCRIPTION
In the INI file, you can define a hook_file and hook_prefix in the [MTT] section.  The hook_file is a .pm file that is required during the client startup.  The hook_prefix is the package name prefix of all the hook functions.

Two hook functions currently exist, but more can be easily added:

* mtt_hook_init
* mtt_hook_finalize

If a given hook function does not exist, it will be skipped (i.e., you do not have to define every hook in your hook file).

Here's an example Cisco_hooks.pm file:

```perl
package Cisco_hooks;

use strict;

sub mtt_hook_init {
    # Do something interesting here
}

1;
```

Notice that it only provides the mtt_hook_init function; the mtt client will detect that the finalize hook is not provided, and will silently/safely skip it.

You can tell the MTT client to use the above file by putting the following in the INI file:

```ini
hook_file = /path/to/Cisco_hooks.pm
hook_prefix = Cisco_hooks::
```