### PR TITLE
hooks: add mtt hooks

### DIFF
--- a/client/mtt
+++ b/client/mtt
@@ -115,9 +115,10 @@ use MTT::Timer;
 use MTT::Util;
 use Filesys::DiskFree;
 
-my @file_arg;
-my $stdin_arg;
-my $scratch_arg;
+my $has_hooks = eval "require MTTHooks;";
+our @file_arg;
+our $stdin_arg;
+our $scratch_arg;
 my $help_arg;
 my $debug_arg;
 my $verbose_arg;
@@ -136,7 +137,7 @@ my @no_section_arg;
 my $no_reporter_arg;
 my $trim_arg;
 my $version_arg;
-my $ini_args;
+our $ini_args;
 my $time_arg;
 my $time_phases_arg;
 my $time_cmd_arg;
@@ -391,10 +392,10 @@ MTT::FindProgram::FindZeroDir();
 ########################################################################
 
 # Convert INI files (or STDIN) to data structure(s)
-my @ini_list = _process_ini_param(\@file_arg, $stdin_arg, \@section_arg, \@no_section_arg);
+our @ini_list = _process_ini_param(\@file_arg, $stdin_arg, \@section_arg, \@no_section_arg);
 
 # Determine scratch from command-line or INI param
-my $scratch_arg = _process_scratch_param("scratch", $scratch_arg, $ini_list[0]->{unfiltered}, ".");
+our $scratch_arg = _process_scratch_param("scratch", $scratch_arg, $ini_list[0]->{unfiltered}, ".");
 $MTT::Globals::Values->{scratch_root} = $scratch_arg;
 MTT::DoCommand::Chdir($scratch_arg);
 
@@ -467,10 +468,14 @@ if (defined($mpi_get_arg) || defined($mpi_install_arg) || defined($mpi_phases_ar
 # Load up all old data
 ########################################################################
 
-my $source_dir = "$scratch_arg/$MTT::Defaults::System_config->{source_subdir}";
-my $install_dir = "$scratch_arg/$MTT::Defaults::System_config->{install_subdir}";
-my $runs_data_dir = "$scratch_arg/$MTT::Defaults::System_config->{runs_data_subdir}";
-my $mpi_install_dir = "$scratch_arg/$MTT::Defaults::System_config->{mpi_install_subdir}";
+our $source_dir = "$scratch_arg/$MTT::Defaults::System_config->{source_subdir}";
+our $install_dir = "$scratch_arg/$MTT::Defaults::System_config->{install_subdir}";
+our $runs_data_dir = "$scratch_arg/$MTT::Defaults::System_config->{runs_data_subdir}";
+our $mpi_install_dir = "$scratch_arg/$MTT::Defaults::System_config->{mpi_install_subdir}";
+
+if ($has_hooks) {
+    MTTHooks::on_start();
+}
 
 # If requested, do a clean start
 if ($clean_start_arg) 
@@ -652,6 +657,10 @@ foreach my $hash (@ini_list) {
 }
 
 # That's it!
+
+if ($has_hooks) {
+    MTTHooks::on_stop();
+}
 
 exit(0);
 

--- a/lib/MTTHooks.pm
+++ b/lib/MTTHooks.pm
@@ -1,0 +1,53 @@
+#
+#
+# Copyright (c) 2015      Mellanox Technologies.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+#
+package MTTHooks;
+
+use MTT::Messages;
+
+use strict;
+
+sub run_ext_hooks()
+{
+    my ($hook_file) = (@_);
+    my @hooks_dirs;
+    push @hooks_dirs, $ENV{'HOME'}    if defined $ENV{'HOME'};
+    push @hooks_dirs, $ENV{'MTT_LIB'} if defined $ENV{'MTT_LIB'};
+
+    foreach my $hook (@hooks_dirs) {
+        my $hfile="$hook/$hook_file";
+
+        MTT::Messages::Verbose("Checking $hfile\n");
+
+        if ( -f $hfile) {
+            MTT::Messages::Verbose("Loading hook $hfile\n");
+            my $cmd = `cat $hfile`;
+            MTT::Messages::Verbose("hook: $cmd\n");
+            eval($cmd);
+        } else {
+            MTT::Messages::Verbose("no hook in $hfile\n");
+        }
+    }
+}
+
+# access global MTT vars defined with 'our' keyword by $main::var
+sub on_start  
+{
+    MTT::Messages::Verbose("Hook on start\n");
+    &run_ext_hooks(".mtt_on_start");
+}
+
+sub on_stop
+{
+    MTT::Messages::Verbose("Hook on stop\n");
+    &run_ext_hooks(".mtt_on_stop");
+}
+
+1;

--- a/tests/hooks_test.pl
+++ b/tests/hooks_test.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+#
+#
+# Copyright (c) 2015      Mellanox Technologies.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+#
+
+
+use strict;
+use lib '../lib';
+use Cwd;
+use MTT::Messages;
+
+my $test_var="hello";
+
+MTT::Messages::Messages(1, 1, cwd(), 1);
+
+if(eval "require MTTHooks;") {
+    print "Using Hooks\n";
+    MTTHooks::on_start();
+} else {
+    print "No hooks for you\n";
+}


### PR DESCRIPTION
lib/MTTHooks.pm can be used to add global hooks per mtt installation
and $HOME/.mtt_on_start, $MTT_LIB/.mtt_on_start files will be consulted
for user defined hooks