### PR TITLE
MPI::OMPI::find_findings correctly handle quoted bindings

### DIFF
--- a/lib/MTT/Values/Functions/MPI/OMPI.pm
+++ b/lib/MTT/Values/Functions/MPI/OMPI.pm
@@ -4,6 +4,8 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -204,7 +206,7 @@ sub find_bindings {
     my ($bindir, $libdir, $lang) = @_;
 
     my $file = _run_ompi_info($bindir, $libdir, "^bindings:$lang:");
-    return ($file->[0] =~ /^bindings:${lang}:yes/) ? "1" : "0";
+    return ($file->[0] =~ /^bindings:${lang}:(")?yes/) ? "1" : "0";
 }
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
until v2.x :
$ ompi_info -all --parseable | grep ^bindings:use_mpi:
bindings:use_mpi:yes (limited: overloading)

but since v2.x :
$ ompi_info -all --parseable | grep ^bindings:use_mpi:
bindings:use_mpi:"yes (limited: overloading)"

so we need to handle the optional double quote before yes...