### PR TITLE
lib/SCM: Remove leading/trailing spaces from scm_url

### DIFF
--- a/lib/MTT/Common/SCM.pm
+++ b/lib/MTT/Common/SCM.pm
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2007-2009 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -21,6 +22,7 @@ use MTT::INI;
 use MTT::DoCommand;
 use MTT::FindProgram;
 use MTT::Module;
+use MTT::Util;
 use Data::Dumper;
 
 #--------------------------------------------------------------------------
@@ -80,7 +82,7 @@ sub Get {
     # Strip off trailing slash for basename
     my $cwd = MTT::DoCommand::cwd();
     $params->{url} =~ s/\/\s*$//;
-    my $basename = basename($params->{url});
+    my $basename = basename( trim_spaces($params->{url}) );
     $params->{dirname} = "$cwd/$basename";
 
     # Remove the cwd portion of the dirname so that we do not erroneously get a

--- a/lib/MTT/Reporter/TextFile.pm
+++ b/lib/MTT/Reporter/TextFile.pm
@@ -4,6 +4,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -829,7 +830,7 @@ sub get_html_summary_report_template
 	}
 	foreach my $section (@sects) 
 	{
-		print("text reporter: section  $section\n");
+		Debug("text reporter: section  $section\n");
 		if ($section =~ /^\s*mpi install:/) 
 		{
 			my $sim_sec_name = GetSimpleSection($section);

--- a/lib/MTT/Util.pm
+++ b/lib/MTT/Util.pm
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2007-2008 Cisco, Inc.  All rights reserved.
 # Copyright (c) 2007 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 # 
 # Additional copyrights may follow
@@ -29,6 +30,7 @@ use base qw(Exporter);
              convert_time_to_human
              get_array_ref
              merge_hashes
+             trim_spaces
 );
 
 use MTT::Globals;
@@ -489,5 +491,14 @@ sub term_handler{
     }
 	Verbose("All is done, exiting.\n");
 	exit(0);
+}
+
+#--------------------------------------------------------------------------
+
+# Trim the leading and trailing whitespaces
+sub trim_spaces {
+    my ($str) = @_;
+    $str =~ s/^\s+|\s+$//g;
+    return $str;
 }
 1;


### PR DESCRIPTION
If you add extra spaces at the end if the scm_url then chdir in ``_git_identify_n`` will throw the error:
 ``fatal: Not a git repository ...``
Seems to only happen on Ubuntu 14.04 (did not have the problem on RHEL 7.2).

 * Minor additional fix to change a debug 'print' to a protected Debug