### PR TITLE
whatami: Add ppc64le support, and alternative RHEL detection

### DIFF
--- a/client/whatami/whatami
+++ b/client/whatami/whatami
@@ -169,6 +169,9 @@ get_linux_type()
                 i386|i486|i586|i686)
                         hardware=ia32
                         ;;
+                ppc64le)
+                        hardware=ppc64le
+                        ;;
                 ppc64)
                         hardware=ppc64
                         ;;
@@ -218,6 +221,11 @@ get_linux_type()
                         #distro_version=`basename ${gentoo_profile}`
                         #distro=${distro_brand}_${distro_version}
                         distro=${distro_brand}
+
+                elif [ -f /etc/redhat-release -a -n "`egrep 'Red Hat Enterprise Linux ([a-zA-Z]+) release [0-9]*' /etc/redhat-release`" ]; then
+                        distro_brand=rhel
+                        distro_version=`grep 'Red Hat' /etc/redhat-release | sed -e 's/Red Hat Enterprise Linux \([a-zA-Z]*\) release \([0-9]*\).*/\2/' `
+                        distro=${distro_brand}${distro_version}
 
                 elif [ -n "`egrep 'Scientific Linux SL release [0-9\.]+' /etc/issue`" ]; then
                         distro_ver="`grep 'Scientific Linux' /etc/issue | sed -e 's/.*release \([0-9]*\.[0-9]*\).*/\1/'`"


### PR DESCRIPTION
* Add support for pcc64le (Power8 arch)
* Add support for an alternative to detecting RHEL version information (we have a system where `/etc/issue` is not reliable)