### PR TITLE
Funclets: add &test_mpirun_args()

### DIFF
--- a/lib/MTT/Test/RunEngine.pm
+++ b/lib/MTT/Test/RunEngine.pm
@@ -230,7 +230,7 @@ sub RunEngine {
         $MTT::Test::Run::test_executable_dir = $test_exe_dir;
         $MTT::Test::Run::test_executable_abspath = $test_exe_abs;
         $MTT::Test::Run::test_executable_basename = $test_exe_basename;
-
+        $MTT::Test::Run::test_mpirun_args = $run->{mpirun_args};
         $MTT::Test::Run::test_argv = $run->{argv};
         my $all_np = MTT::Values::EvaluateString($run->{np}, $ini, $test_run_full_name);
 

--- a/lib/MTT/Values/Functions.pm
+++ b/lib/MTT/Values/Functions.pm
@@ -1095,6 +1095,15 @@ sub test_executable_basename {
 
 #--------------------------------------------------------------------------
 
+# Return mpirun args specified by a test run section
+sub test_mpirun_args {
+    Debug("&test_mpirun_args returning $MTT::Test::Run::test_mpirun_args\n");
+
+    return $MTT::Test::Run::test_mpirun_args;
+}
+
+#--------------------------------------------------------------------------
+
 # Return the current argv (excluding $argv[0]) from a running test
 sub test_argv {
     Debug("&test_argv returning $MTT::Test::Run::test_argv\n");


### PR DESCRIPTION
Allow Specify::Simple to pass tokens to &test_mpirun_args() (i.e., arguments to mpirun itself, not the test executable).  Its intent is to to do something like this:

```
exec = mpirun &test_mpirun_args() -np &test_np() ... &test_executable() &test_argv()
```

You set them in the Test Run section like this:

```
simple_dyn:tests = src/mpi2c++_dynamics_test
simple_dyn:mpirun_args = --oversubscribe --bind-to none
```

The `mpirun_args` clause will get returned from `&test_mpirun_args()`.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@jjhursey Please review.