### PR TITLE
Refactored environment modules plugin to use existing lmod python wra…

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -97,8 +97,8 @@ execGroup.add_option("--group-results", dest="submit_group_results", default=Tru
                      help="Report results from each test section as it is completed")
 execGroup.add_option("--default-make-options", dest="default_make_options", default="-j10",
                      help="Default options when running the \"make\" command")
-execGroup.add_option("--module-cmd", dest="module_cmd", default="module",
-                     help="Command used to load/unload a module")
+execGroup.add_option("--env-module-cmd-path", dest="env_module_cmd_path", default=None,
+                     help="Path to the lmod python env_modules_python.py wrapper")
 parser.add_option_group(execGroup)
 
 debugGroup = OptionGroup(parser, "Debug Options")

--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -97,8 +97,8 @@ execGroup.add_option("--group-results", dest="submit_group_results", default=Tru
                      help="Report results from each test section as it is completed")
 execGroup.add_option("--default-make-options", dest="default_make_options", default="-j10",
                      help="Default options when running the \"make\" command")
-execGroup.add_option("--env-module-cmd-path", dest="env_module_cmd_path", default=None,
-                     help="Path to the lmod python env_modules_python.py wrapper")
+execGroup.add_option("--env-module-wrapper", dest="env_module_wrapper", default=None,
+                     help="Python environment module wrapper")
 parser.add_option_group(execGroup)
 
 debugGroup = OptionGroup(parser, "Debug Options")
@@ -214,6 +214,7 @@ a = cls()
 
 # create the Test Definition object and set the
 # options and arguments
+# create the scratch directory
 testDef = a.__class__();
 testDef.setOptions(options, args)
 

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -55,6 +55,11 @@ class TestDef:
     def setOptions(self, options, args):
         self.options = vars(options)
         self.args = args[:]
+        # if they want us to clear the scratch, then do so
+        if self.options['clean']:
+            shutil.rmtree(self.options['scratchdir'])
+        # setup the scratch directory
+        _mkdir_recursive(self.options['scratchdir'])
 
     # scan the key-value pairs obtained from the configuration
     # parser and compare them with the options defined for a
@@ -455,11 +460,6 @@ class TestDef:
         if not self.tools.getPluginByName(self.options['executor'], "Executor"):
             print "Specified executor",self.executor,"not found"
             exit(1)
-        # if they want us to clear the scratch, then do so
-        if self.options['clean']:
-            shutil.rmtree(self.options['scratchdir'])
-        # setup the scratch directory
-        _mkdir_recursive(self.options['scratchdir'])
         # activate the specified plugin
         self.tools.activatePluginByName(self.options['executor'], "Executor")
         # execute the provided test description

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -177,20 +177,20 @@ class Autotools(BuildMTTTool):
                 for arg in args:
                     agargs.append(arg.strip())
                 status, stdout, stderr = testDef.execmd.execute(agargs, testDef)
-            if 0 != status:
-                log['status'] = status
-                log['stdout'] = stdout
-                log['stderr'] = stderr
-                if usedModule:
-                    # unload the modules before returning
-                    testDef.modcmd.unloadModules(log, cmds['modules'], testDef)
-                # return to original location
-                os.chdir(cwd)
-                return
-            else:
-                # this is a multistep operation, and so we need to
-                # retain the output from each step in the log
-                log['autogen'] = (stdout, stderr)
+                if 0 != status:
+                    log['status'] = status
+                    log['stdout'] = stdout
+                    log['stderr'] = stderr
+                    if usedModule:
+                        # unload the modules before returning
+                        testDef.modcmd.unloadModules(log, cmds['modules'], testDef)
+                    # return to original location
+                    os.chdir(cwd)
+                    return
+                else:
+                    # this is a multistep operation, and so we need to
+                    # retain the output from each step in the log
+                    log['autogen'] = (stdout, stderr)
         except KeyError:
             # autogen phase is not required
             pass

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -23,6 +23,8 @@ class Shell(BuildMTTTool):
         self.options['stdout_save_lines'] = (None, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (None, "Number of lines of stderr to save")
         self.options['save_stdout_on_success'] = (False, "Save stdout even if build succeeds")
+        self.options['modules'] = (None, "Modules to load")
+        self.options['modules_unload'] = (None, "Modules to unload")
         return
 
     def activate(self):
@@ -144,9 +146,15 @@ class Shell(BuildMTTTool):
         # execute the specified command
         cfgargs = cmds['command'].split()
         status, stdout, stderr = testDef.execmd.execute(cfgargs, testDef)
-        log['status'] = status
+        if 0 != status:
+            # return to original location
+            os.chdir(cwd)
+            log['status'] = status
+            log['stdout'] = stdout
+            log['stderr'] = stderr
+            return
+        log['status'] = 0
         log['stdout'] = stdout
-        log['stderr'] = stderr
         # record this location for any follow-on steps
         log['location'] = location
         if usedModule:

--- a/pylib/Utilities/ModuleCmd.py
+++ b/pylib/Utilities/ModuleCmd.py
@@ -10,13 +10,14 @@
 
 import sys
 import select
-import subprocess
+import os
+from StringIO import StringIO
 from BaseMTTUtility import *
 
 class ModuleCmd(BaseMTTUtility):
     def __init__(self):
         BaseMTTUtility.__init__(self)
-        self.command = None
+        self.lmod_env_modules_python_path = None
         self.options = {}
         return
 
@@ -30,42 +31,108 @@ class ModuleCmd(BaseMTTUtility):
         return
 
     def setCommand(self, options):
-        try:
-            self.command = options['module_cmd']
-        except KeyError:
-            print "Module command was not provided"
+        # Check first if the --env-module-cmd-path switch was used.  If not, then check for the LMOD_PKG environment variable.
+        if options['env_module_cmd_path'] is not None:
+            self.lmod_env_modules_python_path = options['env_module_cmd_path']
+            check_if_wrapper_file_exists = os.path.join(self.lmod_env_modules_python_path , "env_modules_python.py")
+            if not os.path.isfile(check_if_wrapper_file_exists):
+                print "Module (lmod) python support via --env-module-cmd-path + env_modules_python.py was not found"
+                return 1
+        else:
+            try:
+                lmod_pkg = os.environ['LMOD_PKG']
+                env_modules_python_path = os.path.join(lmod_pkg, "init")
+                self.lmod_env_modules_python_path = env_modules_python_path
+            except KeyError:
+                print "Module (lmod) python support via os.environ['LMOD_PKG']/init/env_modules_python.py was not found"
+                return 1
         return
 
     def loadModules(self, log, modules, testDef):
-        if self.command is None:
+        if self.lmod_env_modules_python_path is None:
             # cannot perform this operation
             log['status'] = 1
             log['stderr'] = "Module (lmod) capability was not found"
-            return
+            return (1, None, "Module (lmod) capability was not found")
+
+        # Load the lmod python module() definition
+        sys.path.insert(0, self.lmod_env_modules_python_path)
+        try:
+            from env_modules_python import module
+        except:
+            return (1, None, "No module named env_modules_python found")
+
+        # We have to run this in the same python context for it to take effect and be propagated to future children
+        # Redirect the sys.stdout and sys.stderr for the module loads and unloads.
+        saved_stdout = sys.stdout
+        saved_stderr = sys.stderr
+        load_stdout = sys.stdout = StringIO()
+        load_stderr = sys.stderr = StringIO()
+
         modules = modules.split()
         for mod in modules:
             mod = mod.strip()
-            status,stdout,stderr = testDef.execmd.execute([self.command, "load", mod], testDef)
-            if 0 != status:
-                break
+            try:
+                module("load", mod)
+            except:
+                # If a module name is not found the lmod python flow will trigger this exception.
+                return (1, None, "Attempt to load environment module " + mod + " failed")
+
+        # Restore sys.stdout and sys.stderr
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+
+        status = load_stderr.len
+        stdout = load_stdout.getvalue()
+        stderr = load_stderr.getvalue()
+        load_stdout.close()
+        load_stderr.close()
         log['status'] = status
         log['stdout'] = stdout
         log['stderr'] = stderr
-        return
+        return (status, stdout, stderr)
 
     def unloadModules(self, log, modules, testDef):
-        if self.command is None:
+        if self.lmod_env_modules_python_path is None:
             # cannot perform this operation
             log['status'] = 1
             log['stderr'] = "Module (lmod) capability was not found"
-            return
+            return (1, None, "Module (lmod) capability was not found")
+        
+        # Load the lmod python module() definition
+        sys.path.insert(0, self.lmod_env_modules_python_path)
+        try:
+            from env_modules_python import module
+        except:
+            return (1, None, "No module named env_modules_python found")
+
+        # We have to run this in the same python context for it to take effect and be propagated to future children
+        # Redirect the sys.stdout and sys.stderr for the module loads and unloads.
+        saved_stdout = sys.stdout
+        saved_stderr = sys.stderr
+        unload_stdout = sys.stdout = StringIO()
+        unload_stderr = sys.stderr = StringIO()
+
         modules = modules.split()
         for mod in modules:
             mod = mod.strip()
-            status,stdout,stderr = testDef.execmd.execute([self.command, "unload", mod], testDef)
-            if 0 != status:
-                break
+            try:
+                module("unload", mod)
+            except:
+                # Unlike the load, the lmod python flow will not cause an exception if the module can not be found.  
+                # Add this to catch any other unexpected exceptions.
+                return (1, None, "Attempt to unload environment module " + mod + " failed")
+
+        # Restore sys.stdout and sys.stderr
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+
+        status = unload_stderr.len
+        stdout = unload_stdout.getvalue()
+        stderr = unload_stderr.getvalue()
+        unload_stdout.close()
+        unload_stderr.close()
         log['status'] = status
         log['stdout'] = stdout
         log['stderr'] = stderr
-        return
+        return (status, stdout, stderr)


### PR DESCRIPTION
…pper.  That wrapper uses python exec which sets the env module context in the pyclient parent context

which carries through to subsequent subprocess invocation contexts.
Added --env-module-cmd-path to allow user to point to lmod install if not set in LMOD_PKG.
Fixed a bug in the Autotools plugin exception handling which prevented running without the autogen phase.
Added module and module_unload to the Shell plugin options.  Also added status check for Shell plugin command execution.
Added module and module_unload to the SLURM plugin options.  Added SLURM plugin support for both load and unload of modules based on previous middleware or build stages.