### PR TITLE
Analyze: allow treating timeouts as failures

### DIFF
--- a/lib/MTT/Test/Analyze/Correctness.pm
+++ b/lib/MTT/Test/Analyze/Correctness.pm
@@ -29,6 +29,19 @@ sub Analyze {
         $pass = MTT::Values::EvaluateString($run->{pass});
     }
 
+    # If treat_timeouts_as_fail==1 and we timed out, then override it
+    if (defined($results->{timed_out}) && $results->{timed_out} == 1 &&
+        defined($run->{treat_timeouts_as_fail}) &&
+        $run->{treat_timeouts_as_fail} == 1) {
+        Debug("*** Timeout converted to failure\n");
+
+        $results->{result_stdout} .=
+            "\n==> MTT: Test timed out, but reclassified as a failure";
+
+        $results->{timed_out} = 0;
+        $pass = 0;
+    }
+
     # result value: 0=fail, 1=pass, 2=skipped, 3=timed out
     my $result = MTT::Values::FAIL;
     if ($skipped) {

--- a/lib/MTT/Test/Run.pm
+++ b/lib/MTT/Test/Run.pm
@@ -522,6 +522,9 @@ sub _do_run {
     $tmp = $ini->val($section, "timeout");
     $config->{timeout} = $tmp
         if (defined($tmp));
+    $tmp = $ini->val($section, "treat_timeouts_as_fail");
+    $config->{treat_timeouts_as_fail} = $tmp
+        if (defined($tmp));
 
     $MTT::Test::Run::mpi_details = undef;
     foreach my $field ($ini->Parameters($section)) {


### PR DESCRIPTION
Per request from the Open MPI community, add a parameter
"treat_timeouts_as_fail" to be set in Test Run sections that, upon
result of a timeout, will override that result and classify it as a
failure.

The rationale is that timeouts are not frequently examined in the web
reporter, and at least some kinds of test should treat timeouts as
failures.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@miked-mellanox @jjhursey 