### PR TITLE
Cleanup several bugs that prevented the Python client from executing cleanly:

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -29,7 +29,7 @@ import argparse
 # define the cmd line arguments
 parser = argparse.ArgumentParser(description="usage: %prog [options] testfile1 testfile2 ...")
 
-parser.add_argument('ini_files', action='append', metavar='FILE', nargs='+', help = ".ini file to be used")
+parser.add_argument('ini_files', action='append', metavar='FILE', nargs='*', help = ".ini file to be used")
 
 infoGroup = parser.add_argument_group('InfoGroup','Informational Options')
 infoGroup.add_argument("-v", "--version",

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -76,20 +76,20 @@ class IUDatabase(ReporterMTTStage):
             return
         try:
             if cmds['pwfile'] is not None:
-                if os.path.exists(cmds['pwfile'][0]):
-                    f = open(cmds['pwfile'][0], 'r')
+                if os.path.exists(cmds['pwfile']):
+                    f = open(cmds['pwfile'], 'r')
                     password = f.readline().strip()
                     f.close()
                 else:
                     log['status'] = 1;
-                    log['stderr'] = "Password file " + cmds['pwfile'][0] + " does not exist"
+                    log['stderr'] = "Password file " + cmds['pwfile'] + " does not exist"
                     return
             elif cmds['password'] is not None:
                 password = cmds['password']
         except KeyError:
             try:
                 if cmds['password'] is not None:
-                    password = cmds['password'][0]
+                    password = cmds['password']
             except KeyError:
                 pass
         #
@@ -340,7 +340,7 @@ class IUDatabase(ReporterMTTStage):
             for entry in full_log:
                 if 'compiler' in entry:
                     data['compiler_name'] = entry['compiler']['compiler']
-                    data['compiler_version'] = entry['compiler']['version'] 
+                    data['compiler_version'] = entry['compiler']['version']
                     break
             else:
                 data['compiler_name'] = None
@@ -481,7 +481,7 @@ class IUDatabase(ReporterMTTStage):
             for entry in full_log:
                 if 'compiler' in entry:
                     data['compiler_name'] = entry['compiler']['compiler']
-                    data['compiler_version'] = entry['compiler']['version'] 
+                    data['compiler_version'] = entry['compiler']['version']
                     break
             else:
                 data['compiler_name'] = None

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -167,7 +167,7 @@ class Autotools(BuildMTTTool):
             compilerLog = {}
             plugin.execute(compilerLog, testDef)
             log['compiler'] = compilerLog
-        print(log['compiler'])
+        testDef.logger.verbose_print(log['compiler'])
 
         # Find MPI information for IUDatabase plugin
         plugin = None

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -70,6 +70,7 @@ class OpenMPI(LauncherMTTTool):
                     # transfer the findings into our local storage
                     keys = list(self.options.keys())
                     optkeys = list(myopts.keys())
+                    print ("OMPI OPTIONS: " + myopts['command'])
                     for optkey in optkeys:
                         for key in keys:
                             if key == optkey:
@@ -228,8 +229,8 @@ class OpenMPI(LauncherMTTTool):
         # get the "skip" exit status
         skipStatus = int(cmds['skipped'])
         # assemble the command
-        cmdargs = [cmds['command']]
-        if cmds['np'] is not None:
+        cmdargs = cmds['command'].split()
+        if ['np'] is not None:
             cmdargs.append("-np")
             cmdargs.append(cmds['np'])
         if cmds['hostfile'] is not None:
@@ -276,8 +277,8 @@ class OpenMPI(LauncherMTTTool):
         log['numSkip'] = numSkip
         log['numFail'] = numFail
         try:
-	    log['np'] = cmds['np']
+            log['np'] = cmds['np']
         except KeyError:
-	    log['np'] = None
+            log['np'] = None
         os.chdir(cwd)
         return

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -70,7 +70,6 @@ class OpenMPI(LauncherMTTTool):
                     # transfer the findings into our local storage
                     keys = list(self.options.keys())
                     optkeys = list(myopts.keys())
-                    print ("OMPI OPTIONS: " + myopts['command'])
                     for optkey in optkeys:
                         for key in keys:
                             if key == optkey:

--- a/pylib/Utilities/MPIVersion.py
+++ b/pylib/Utilities/MPIVersion.py
@@ -35,7 +35,7 @@ class MPIVersion(BaseMTTUtility):
             log['name'] = 'None'
             log['version'] = 'Unknown'
             return
-        
+
         name = None
         version = None
 
@@ -60,7 +60,7 @@ class MPIVersion(BaseMTTUtility):
             name = 'MVAPICH2'
             version = version_str.split('MVAPICH2 Version')[1].split(':')[1].split('\n')[0].strip()
         # Intel MPI
-        # Example Output:        
+        # Example Output:
         # Intel(R) MPI Library 5.1.3 for Linux* OS
         elif 'Intel' in version_str:
             name = 'Intel MPI'
@@ -87,10 +87,11 @@ class MPIVersion(BaseMTTUtility):
 #include <stdio.h>
 int main(int argc, char **argv) {
     MPI_Init(NULL, NULL);
-    char version[1000];
+    char version[3000];
     int resultlen;
     MPI_Get_library_version(version, &resultlen);
     printf("%s\\n", version);
+    MPI_Finalize();
     return 0;
 }""")
         fh.close()
@@ -107,7 +108,7 @@ int main(int argc, char **argv) {
             if os.path.exists("mpi_get_version.c"): os.remove("mpi_get_version.c")
             os.chdir("..")
             return None
-        
+
         if os.path.exists("mpi_get_version"): os.remove("mpi_get_version")
         if os.path.exists("mpi_get_version.c"): os.remove("mpi_get_version.c")
         os.chdir("..")


### PR DESCRIPTION
* do not require a .ini file just to ask for --list-stages and other info cmds

* move the compiler output line to debug prints

* properly parse the OMPI cmd line into a list

* properly call MPI_Finalize at the end of mpi_get_version so we don't segfault