### PR TITLE
Corrected , to + in print statement in Logger

### DIFF
--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -81,7 +81,7 @@ class Logger(BaseMTTUtility):
 
     def verbose_print(self, str):
         if self.printout:
-            print(str, file=self.fh)
+            print(str + file=self.fh)
         return
 
     def timestamp(self):


### PR DESCRIPTION
was causing an ascii encode error when using --verbose

Signed-off-by: Deb Rezanka <drezanka@newmexicoconsortium.org>

@noahv 