### PR TITLE
Add Test Run "corefile_size_limit" param to the perl MTT client

### DIFF
--- a/lib/MTT/Test/Run.pm
+++ b/lib/MTT/Test/Run.pm
@@ -525,6 +525,12 @@ sub _do_run {
     $tmp = $ini->val($section, "treat_timeouts_as_fail");
     $config->{treat_timeouts_as_fail} = $tmp
         if (defined($tmp));
+    $config->{corefile_size_limit} = -1;
+    $tmp = $ini->val($section, "corefile_size_limit");
+    $config->{corefile_size_limit} = $tmp
+        if (defined($tmp));
+
+    MTT::DoCommand::set_corefile_size_limit($config->{corefile_size_limit});
 
     $MTT::Test::Run::mpi_details = undef;
     foreach my $field ($ini->Parameters($section)) {


### PR DESCRIPTION
If set to >= 0, setrlimit to limit corefiles to that size.  If set to a negative number, corefile sizes are unlimited.  The default is unlimited corefiles.

This functionality requires the `BSD::Resource` perl module.  If you don't have it (and we therefore can't set corefile size limits), you'll get an error (because it would be worse to generate gigabytes / terrabytes of corefiles when you specifically asked us not to).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@jjhursey Please review.