### PR TITLE
Fixed fields passed into reporter

### DIFF
--- a/pylib/Stages/Profile/DefaultProfile.py
+++ b/pylib/Stages/Profile/DefaultProfile.py
@@ -67,13 +67,14 @@ class DefaultProfile(ProfileMTTStage):
         opts = self.options.keys()
         for key in keys:
             if cmds[key] and key in opts:
+#                import pdb; pdb.set_trace()
                 status, stdout, stderr = testDef.execmd.execute(cmds, self.options[key][2], testDef)
                 if 0 != status:
                     log['status'] = status
                     log['stdout'] = stdout
                     log['stderr'] = stderr
                     return
-                myLog[key] = stdout
+                myLog[key] = "\n".join(stdout)
         # add our log to the system log
         log['profile'] = myLog
         log['status'] = 0

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -469,7 +469,6 @@ class IUDatabase(ReporterMTTStage):
         except KeyError:
             data['result_stderr'] = None
 
-
         #
         # Submit
         #

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -71,6 +71,7 @@ class Autotools(BuildMTTTool):
         return
 
     def execute(self, log, keyvals, testDef):
+
         testDef.logger.verbose_print("Autotools Execute")
         # parse any provided options - these will override the defaults
         cmds = {}

--- a/pylib/Utilities/Compilers.py
+++ b/pylib/Utilities/Compilers.py
@@ -212,5 +212,5 @@ class Compilers(BaseMTTUtility):
         # try the universal version option
         mycmdargs = [compiler, version]
         status, stdout, stderr = testDef.execmd.execute(None, mycmdargs, testDef)
-        return status, stdout
+        return status, "\n".join(stdout)
 


### PR DESCRIPTION
Reporter wasn't working since some fields were passed in as lists. I fixed this by joining the lists together.

I also realized that the "result_stderr" bad-format problem wasn't occurring. Maybe that bug was already fixed. -- Bug #468 