### PR TITLE
Add harasser utility

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -56,9 +56,6 @@ infoGroup.add_argument("--list-tool-options",
 infoGroup.add_argument("--list-utilities",
                      action="store_true", dest="listutils", default=False,
                      help="List utilities available to this client")
-infoGroup.add_argument("--list-utility-plugins",
-                     action="store", dest="listutilmodules", metavar="TYPE",
-                     help="List available modules for TYPE (* => all)")
 infoGroup.add_argument("--list-utility-options",
                      action="store", dest="listutiloptions", metavar="UTILITY",
                      help="List available options for UTILITY (* => all)")
@@ -266,9 +263,9 @@ elif(testDef.config.has_option('MTTDefaults', 'executor')):
         testDef.executeCombinatorial()
     else:
         print("Specified executor ", testDef.config.get('MTTDefaults', 'executor'), " not found!")
-        sys.exit(1)  
+        sys.exit(1)
 # If no executor is specified default to sequential
 else:
     testDef.config.set('MTTDefaults', 'executor', 'sequential')
-    testDef.executeTest()  
+    testDef.executeTest()
 # All done!

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -442,46 +442,27 @@ class TestDef(object):
         # Print the available MTT utilities out, if requested
         if self.options['listutils']:
             print("Available MTT utilities:")
-            availUtils = list(self.loader.utilities.keys())
-            for util in availUtils:
-                print("    " + util)
+            availUtil = list(self.loader.utilities.keys())
+            for util in availUtil:
+                for pluginInfo in self.utilities.getPluginsOfCategory(util):
+                    print("    " + pluginInfo.plugin_object.print_name())
             exit(0)
-
-        # Print the detected utility plugins for a given tool type
-        if self.options['listutilmodules']:
-            # if the list is '*', print the plugins for every type
-            if self.options['listutilmodules'] == "*":
-                print()
-                availUtils = list(self.loader.utilities.keys())
-            else:
-                availUtils = self.options['listutilitymodules'].split(',')
-            print()
-            for util in availUtils:
-                print(util + ":")
-                try:
-                    for pluginInfo in self.utilities.getPluginsOfCategory(util):
-                        print("    " + pluginInfo.plugin_object.print_name())
-                except KeyError:
-                    print("    Invalid utility type name")
-                print()
-            exit(1)
 
         # Print the options for a given plugin
         if self.options['listutiloptions']:
-            # if the list is '*', print the options for every stage/plugin
-            if self.options['listutiloptions'] == "*":
-                availUtils = list(self.loader.utilities.keys())
-            else:
-                availUtils = self.options['listutiloptions'].split(',')
             print()
+            availUtils = list(self.loader.utilities.keys())
             for util in availUtils:
                 print(util + ":")
-                try:
-                    for pluginInfo in self.utilities.getPluginsOfCategory(util):
+                for pluginInfo in self.utilities.getPluginsOfCategory(util):
+                    if self.options['listutiloptions'] == "*":
                         print("    " + pluginInfo.plugin_object.print_name() + ":")
                         pluginInfo.plugin_object.print_options(self, "        ")
-                except KeyError:
-                    print("    Invalid utility type name " + util)
+                    else:
+                        tmp = pluginInfo.plugin_object.print_name()
+                        if tmp in self.options['listutiloptions']:
+                            print("    " + tmp + ":")
+                            pluginInfo.plugin_object.print_options(self, "        ")
                 print()
             exit(1)
 

--- a/pylib/Utilities/Harasser.py
+++ b/pylib/Utilities/Harasser.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2016      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+from __future__ import print_function
+import os
+from multiprocessing import Process
+from BaseMTTUtility import *
+
+## @addtogroup Utilities
+# @{
+# @section Harasser
+# @}
+class Harasser(BaseMTTUtility):
+    def __init__(self):
+        BaseMTTUtility.__init__(self)
+        self.options = {}
+        return
+
+    def print_name(self):
+        return "Harasser"
+
+    def print_options(self, testDef, prefix):
+        lines = testDef.printOptions(self.options)
+        for line in lines:
+            print(prefix + line)
+        return
+
+    def start(self, fn, params):
+        if params is not None:
+            if type(params) is list:
+                # convert to tuple
+                tparams = tuple(params)
+            elif type(params) is tuple:
+                tparams = params
+            else:
+                # insert the value into a tuple
+                tparams = (params,)
+            # define the process
+            self.p = Process(target=fn, args=(tparams))
+        else:
+            # define the process without any args
+            self.p = Process(target=fn)
+        # spawn the new process
+        self.p.start()
+        return
+
+    def stop(self):
+        self.p.join()
+        return self.p.exitcode
+
+    def is_alive(self):
+        return self.p.is_alive()
+
+    def pid(self):
+        return self.p.pid()
+
+# usage
+#
+# harasser = testDef.harasser(fn, )

--- a/pylib/Utilities/Harasser.yapsy-plugin
+++ b/pylib/Utilities/Harasser.yapsy-plugin
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2016      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+[Core]
+Name = Harasser
+Module = Harasser
+
+[Documentation]
+Author = Ralph Castain
+Version = 0.1
+Website = N/A
+Description = Spawn a harasser job


### PR DESCRIPTION
I haven't been able to figure out how to deal with the Python 2.7 vs Python 3.4 compatibility issue for one key place. In testDef.py, line 337, we need to set the multiprocessing launch method to "spawn" so we ensure that the subprocess is in its own process. This ensures that the Python global lock doesn't take affect and prevent the new process from making independent progress.

Could use some help in that regard.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>