### PR TITLE
Negative test support implemented (Solves issue #499)

### DIFF
--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -212,8 +212,9 @@ class IUDatabase(ReporterMTTStage):
         # and all of the tests that follow are from that test_build
         common_data['test_build_id'] = test_info['test_build_id']
 
+        #import pdb; pdb.set_trace()
 
-        for trun in lg['testresults']:
+        for trun in (lg['testresults'] if 'testresults' in lg else [lg]):
             data = {}
 
             #data['mpi_install_id'] = common_data['mpi_install_id']
@@ -224,16 +225,25 @@ class IUDatabase(ReporterMTTStage):
             except KeyError:
                 data['launcher'] = None
 
-            data['test_name'] = trun['test'].split('/')[-1]
+            if 'testresults' in lg:
+                data['test_name'] = trun['test'].split('/')[-1]
+            else:
+                data['test_name'] = trun['options']['command'].split('/')[-1]
 
             # Number of processes field
 
             try:
-                data['np'] = lg['np']
+                if 'testresults' in lg:
+                    data['np'] = lg['np']
+                else:
+                    data['np'] = 1
             except KeyError:
                 data['np'] = None
 
-            data['command'] = trun['cmd']
+            if 'testresults' in lg:
+                data['command'] = trun['cmd']
+            else:
+                data['command'] = trun['options']['command']
 
             # For now just mark the time when submitted
             data['start_timestamp'] = datetime.utcnow().strftime("%c")
@@ -311,15 +321,15 @@ class IUDatabase(ReporterMTTStage):
                 data['merge_stdout_stderr'] = None
 
             try:
-                data['result_stdout'] = '\n'.join(trun['stdout'])
+                data['result_stdout'] = '\n'.join(trun['stdout'] if trun['stdout'] is not None else "")
             except KeyError:
                 data['result_stdout'] = None
 
             try:
                 if type(trun['stderr']) is list:
-                    data['result_stderr'] = '\n'.join(trun['stderr'])
+                    data['result_stderr'] = '\n'.join(trun['stderr'] if trun['stderr'] is not None else "")
                 else:
-                    data['result_stderr'] = trun['stderr']
+                    data['result_stderr'] = (trun['stderr'] if trun['stderr'] is not None else "")
             except KeyError:
                 data['result_stderr'] = None
 

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -26,6 +26,7 @@ from LauncherMTTTool import *
 # @param save_stdout_on_pass       Whether or not to save stdout on passed tests
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param fail_tests                Names of tests that are expected to fail
+# @param fail_returncodes          Expected returncodes of tests expected to fail
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param command                   Command for executing the application
 # @param timeout                   Maximum execution time - terminate a test if it exceeds this time
@@ -291,7 +292,7 @@ class ALPS(LauncherMTTTool):
         # cycle thru the list of tests and execute each of them
         log['testresults'] = []
         finalStatus = 0
-        finalError = None
+        finalError = ""
         numTests = 0
         numPass = 0
         numSkip = 0
@@ -330,21 +331,50 @@ class ALPS(LauncherMTTTool):
             # not required to provide a module to unload
             pass
 
+        fail_tests = cmds['fail_tests']
+        if fail_tests is not None:
+            fail_tests = [t.strip() for t in fail_tests.split(",")]
+        for i,t in enumerate(fail_tests):
+            for t2 in tests:
+                if t2.split("/")[-1] == t:
+                    fail_tests[i] = t2
+        fail_returncodes = cmds['fail_returncodes']
+        if fail_returncodes is not None:
+            fail_returncodes = [int(t.strip()) for t in fail_returncodes.split(",")]
+
+        if fail_tests is None:
+            expected_returncodes = {test:0 for test in tests}
+        else:
+            if fail_returncodes is None:
+                expected_returncodes = {test:(None if test in fail_tests else 0) for test in tests}
+            else:
+                fail_returncodes = {test:rtncode for test,rtncode in zip(fail_tests,fail_returncodes)}
+                expected_returncodes = {test:(fail_returncodes[test] if test in fail_returncodes else 0) for test in tests}
+
         for test in tests:
             testLog = {'test':test}
             cmdargs.append(test)
             testLog['cmd'] = " ".join(cmdargs)
             status,stdout,stderr = testDef.execmd.execute(cmds, cmdargs, testDef)
-            testLog['status'] = status
             if 0 != status and skipStatus != status and 0 == finalStatus:
-                finalStatus = status
+                if expected_returncodes[test] == 0:
+                    finalStatus = status
+                else:
+                    finalStatus = 1
                 finalError = stderr
-            if 0 == status:
+            if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
                 numPass = numPass + 1
             elif skipStatus == status:
                 numSkip = numSkip + 1
             else:
                 numFail = numFail + 1
+            if expected_returncodes[test] == 0:
+                testLog['status'] = status
+            else:
+                if status == expected_returncodes[test]:
+                    testLog['status'] = 0
+                else:
+                    testLog['status'] = 1
             testLog['stdout'] = stdout
             testLog['stderr'] = stderr
             log['testresults'].append(testLog)

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -25,6 +25,7 @@ from LauncherMTTTool import *
 # @param save_stdout_on_pass       Whether or not to save stdout on passed tests
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param fail_tests                Names of tests that are expected to fail
+# @param fail_returncodes          Expected return codes of tests expected to fail
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param command                   Command for executing the application
 # @param timeout                   Maximum execution time - terminate a test if it exceeds this time
@@ -52,6 +53,7 @@ class OpenMPI(LauncherMTTTool):
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
         self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
+        self.options['fail_returncodes'] = (None, "Expected returncodes of tests expected to fail")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")
@@ -250,7 +252,7 @@ class OpenMPI(LauncherMTTTool):
         skipStatus = int(cmds['skipped'])
         # assemble the command
         cmdargs = cmds['command'].split()
-        if ['np'] is not None:
+        if cmds['np'] is not None:
             cmdargs.append("-np")
             cmdargs.append(cmds['np'])
         if cmds['hostfile'] is not None:
@@ -259,7 +261,7 @@ class OpenMPI(LauncherMTTTool):
         # cycle thru the list of tests and execute each of them
         log['testresults'] = []
         finalStatus = 0
-        finalError = None
+        finalError = ""
         numTests = 0
         numPass = 0
         numSkip = 0
@@ -268,21 +270,51 @@ class OpenMPI(LauncherMTTTool):
             maxTests = int(cmds['max_num_tests'])
         else:
             maxTests = 10000000
+
+        fail_tests = cmds['fail_tests']
+        if fail_tests is not None:
+            fail_tests = [t.strip() for t in fail_tests.split(",")]
+        for i,t in enumerate(fail_tests):
+            for t2 in tests:
+                if t2.split("/")[-1] == t:
+                    fail_tests[i] = t2
+        fail_returncodes = cmds['fail_returncodes']
+        if fail_returncodes is not None:
+            fail_returncodes = [int(t.strip()) for t in fail_returncodes.split(",")]
+
+        if fail_tests is None:
+            expected_returncodes = {test:0 for test in tests}
+        else:
+            if fail_returncodes is None:
+                expected_returncodes = {test:(None if test in fail_tests else 0) for test in tests}
+            else:
+                fail_returncodes = {test:rtncode for test,rtncode in zip(fail_tests,fail_returncodes)}
+                expected_returncodes = {test:(fail_returncodes[test] if test in fail_returncodes else 0) for test in tests}
+
         for test in tests:
             testLog = {'test':test}
             cmdargs.append(test)
             testLog['cmd'] = " ".join(cmdargs)
             status,stdout,stderr = testDef.execmd.execute(cmds, cmdargs, testDef)
-            testLog['status'] = status
-            if 0 != status and skipStatus != status and 0 == finalStatus:
-                finalStatus = status
+            if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
+                if expected_returncodes[test] == 0:
+                    finalStatus = status
+                else:
+                    finalStatus = 1
                 finalError = stderr
-            if 0 == status:
+            if (expected_returncodes[test] is None and 0 != status) or (expected_returncodes[test] == status):
                 numPass = numPass + 1
             elif skipStatus == status:
                 numSkip = numSkip + 1
             else:
                 numFail = numFail + 1
+            if expected_returncodes[test] == 0:
+                testLog['status'] = status
+            else:
+                if status == expected_returncodes[test]:
+                    testLog['status'] = 0
+                else:
+                    testLog['status'] = 1
             testLog['stdout'] = stdout
             testLog['stderr'] = stderr
             log['testresults'].append(testLog)


### PR DESCRIPTION
These plugins now have negative test support:
* SLURM.py
* OpenMPI.py
* ALPS.py
* Shell.py

Also, since Shell.py is a "TestBuild" plugin yet is still sometimes used in TestRun phase, I implemented support for IUDatabase.py to handle the log output of Shell.py

Signed-off-by: Richard Barella <richard.t.barella@intel.com>