### PR TITLE
Fixes Issue #513: Compiler version truncated to fit in database variable

### DIFF
--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -288,6 +288,8 @@ class IUDatabase(ReporterMTTStage):
                             data['exit_value'] = int(lgerr.split("[Errno ")[1].split("]")[0])
                         except:
                             data['exit_value'] = -1
+                    else:
+                        data['exit_value'] = -1
                 else:
                     data['exit_value'] = -1
 
@@ -381,13 +383,15 @@ class IUDatabase(ReporterMTTStage):
 
         try:
             data['compiler_name'] = lg['compiler']['compiler']
-            data['compiler_version'] = "\n".join(lg['compiler']['version'])
+#            data['compiler_version'] = "\n".join(lg['compiler']['version'])
+            data['compiler_version'] = lg['compiler']['version']
         except KeyError:
             full_log = logger.getLog(None)
             for entry in full_log:
                 if 'compiler' in entry:
                     data['compiler_name'] = entry['compiler']['compiler']
-                    data['compiler_version'] = "\n".join(entry['compiler']['version'])
+#                    data['compiler_version'] = "\n".join(entry['compiler']['version'])
+                    data['compiler_version'] = entry['compiler']['version']
                     break
             else:
                 data['compiler_name'] = None
@@ -423,6 +427,8 @@ class IUDatabase(ReporterMTTStage):
                         data['exit_value'] = int(lgerr.split("[Errno ")[1].split("]")[0])
                     except:
                         data['exit_value'] = -1
+                else:
+                    data['exit_value'] = -1
             else:
                 data['exit_value'] = -1
         else:
@@ -442,6 +448,8 @@ class IUDatabase(ReporterMTTStage):
                         data['exit_value'] = int(lgerr.split("[Errno ")[1].split("]")[0])
                     except:
                         data['exit_value'] = -1
+                else:
+                    data['exit_value'] = -1
             else:
                 data['exit_value'] = -1
 
@@ -542,13 +550,15 @@ class IUDatabase(ReporterMTTStage):
 
         try:
             data['compiler_name'] = lg['compiler']['compiler']
-            data['compiler_version'] = "\n".join(lg['compiler']['version'])
+#            data['compiler_version'] = "\n".join(lg['compiler']['version'])
+            data['compiler_version'] = lg['compiler']['version']
         except KeyError:
             full_log = logger.getLog(None)
             for entry in full_log:
                 if 'compiler' in entry:
                     data['compiler_name'] = entry['compiler']['compiler']
-                    data['compiler_version'] = "\n".join(entry['compiler']['version'])
+#                    data['compiler_version'] = "\n".join(entry['compiler']['version'])
+                    data['compiler_version'] = entry['compiler']['version']
                     break
             else:
                 data['compiler_name'] = None
@@ -601,6 +611,8 @@ class IUDatabase(ReporterMTTStage):
                         data['exit_value'] = int(lgerr.split("[Errno ")[1].split("]")[0])
                     except:
                         data['exit_value'] = -1
+                else:
+                    data['exit_value'] = -1
             else:
                 data['exit_value'] = -1
         else:
@@ -620,6 +632,8 @@ class IUDatabase(ReporterMTTStage):
                         data['exit_value'] = int(lgerr.split("[Errno ")[1].split("]")[0])
                     except:
                         data['exit_value'] = -1
+                else:
+                    data['exit_value'] = -1
             else:
                 data['exit_value'] = -1
 

--- a/pylib/Utilities/Compilers.py
+++ b/pylib/Utilities/Compilers.py
@@ -167,7 +167,7 @@ class Compilers(BaseMTTUtility):
         # record the result
         log['status'] = status
         log['compiler'] = compiler
-        log['version'] = "\n".join(vsn)[:64]
+        log['version'] = vsn[0][:64]
         return
 
     def check_compile(self, testDef, macro, c_code, compiler):

--- a/pylib/Utilities/Compilers.py
+++ b/pylib/Utilities/Compilers.py
@@ -167,7 +167,7 @@ class Compilers(BaseMTTUtility):
         # record the result
         log['status'] = status
         log['compiler'] = compiler
-        log['version'] = vsn
+        log['version'] = "\n".join(vsn)[:64]
         return
 
     def check_compile(self, testDef, macro, c_code, compiler):


### PR DESCRIPTION
The compiler version was sometimes longer than 64 bytes (depending on the version, sometimes copyright information and other types of information were also included).
Truncating the compiler version to be max 64 bytes allows it to always fit within the database while still capturing enough information to determine compiler version.

Another thing that was fixed was that exit_value was sometimes not logged to DB. I fixed this by adding some more conditionals to ensure that exit_value is always logged.

Signed-off-by: Richard Barella <richard.t.barella@intel.com>