### PR TITLE
Add environment variable input into INI files

### DIFF
--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -498,9 +498,16 @@ class TestDef(object):
 
     def configTest(self):
         # setup the configuration parser
-        self.config = configparser.ConfigParser()
+        self.config = configparser.SafeConfigParser(interpolation=configparser.ExtendedInterpolation())
+
         # Set the config parser to make option names case sensitive.
         self.config.optionxform = str
+
+        # fill ENV section with environemt variables
+        self.config.add_section('ENV')
+        for k,v in os.environ.items():
+            self.config.set('ENV', k, v.replace("$","$$"))
+
         # log the list of files - note that the argument parser
         # puts the input files in a list, with the first member
         # being the list of input files


### PR DESCRIPTION
INI files now support "ExtendedInterpolation" syntax (https://docs.python.org/3.3/library/configparser.html)

Syntax goes like this:
    ${section:option}

This syntax can be inserted into INI values (not keys) and can interpolate data from other sections as well as from environment variables.

Basically, the ${section:option} syntax is replaced with its corresponding value within the INI file.

This can be used for making INI files more flexible and less hard-coded.

Example of interpolating variables from MTTDefaults section:
    ${MTTDefaults:scratch}

Example of interpolating environment variable PATH:
    ${ENV:PATH}

There is an invisible "ENV" section which all environment variables are stuffed into before reading INI file.

Signed-off-by: Richard Barella <richard.t.barella@intel.com>