### PR TITLE
Any delimiter (not just ":") can now be used in INI files

### DIFF
--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -128,7 +128,8 @@ class IUDatabase(ReporterMTTStage):
 
         data = {}
 
-        profile = testDef.logger.getLog('Profile:Installed')
+        profile = [lg for lg in testDef.logger.getLog(None) if 'Profile' in lg['section'] and 'Installed' in lg['section']][0]
+#        profile = testDef.logger.getLog('Profile:Installed')
         metadata = {}
         metadata['client_serial'] = client_serial
         metadata['hostname'] = "\n".join(profile['profile']['nodeName'])

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -129,7 +129,6 @@ class IUDatabase(ReporterMTTStage):
         data = {}
 
         profile = [lg for lg in testDef.logger.getLog(None) if 'Profile' in lg['section'] and 'Installed' in lg['section']][0]
-#        profile = testDef.logger.getLog('Profile:Installed')
         metadata = {}
         metadata['client_serial'] = client_serial
         metadata['hostname'] = "\n".join(profile['profile']['nodeName'])
@@ -212,8 +211,6 @@ class IUDatabase(ReporterMTTStage):
         # For now assume that we only had one test_build submitted
         # and all of the tests that follow are from that test_build
         common_data['test_build_id'] = test_info['test_build_id']
-
-        #import pdb; pdb.set_trace()
 
         for trun in (lg['testresults'] if 'testresults' in lg else [lg]):
             data = {}
@@ -517,7 +514,7 @@ class IUDatabase(ReporterMTTStage):
         options = None
 
         # get the system profile
-        profile = logger.getLog('Profile:Installed')['profile']
+        profile = [lg for lg in testDef.logger.getLog(None) if 'Profile' in lg['section'] and 'Installed' in lg['section']][0]
         if profile is None:
             print("Error: Failed to get 'profile'")
             return None

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -80,12 +80,17 @@ class SequentialEx(ExecutorMTTTool):
                 # this section
                 if "SKIP" in title:
                     continue
+
+                if 'MTTDefaults' in title and 'LTP' in title:
+                    import pdb; pdb.set_trace()
+
                 # extract the stage and stage name from the title
-                if ":" in title:
-                    stage,name = title.split(':')
-                    stage = stage.strip()
-                else:
-                    stage = title
+                stage = title.split(step)[0] + step
+#                if ":" in title:
+#                    stage,name = title.split(':')
+#                    stage = stage.strip()
+#                else:
+#                    stage = title
                 # setup the log
                 stageLog = {'section':title}
                 # get the key-value tuples output by the configuration parser

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -81,16 +81,8 @@ class SequentialEx(ExecutorMTTTool):
                 if "SKIP" in title:
                     continue
 
-                if 'MTTDefaults' in title and 'LTP' in title:
-                    import pdb; pdb.set_trace()
-
                 # extract the stage and stage name from the title
                 stage = title.split(step)[0] + step
-#                if ":" in title:
-#                    stage,name = title.split(':')
-#                    stage = stage.strip()
-#                else:
-#                    stage = title
                 # setup the log
                 stageLog = {'section':title}
                 # get the key-value tuples output by the configuration parser


### PR DESCRIPTION
Code before required ":" to be used as a delimiter between stage and name. Based on how the information was stored in the log, the delimiter didn't make sense. Also, the title (title=stage+name) with ":" in it was causing an issue with some makefiles. This fix provides freedom in title naming.

[MTTDefaultsIsAVeryCoolStage] is now a valid title.

[TestRun--projectAwesome] is also now a valid title.

As well as [TestGet:GrabMyFiles]

Signed-off-by: Richard Barella <richard.t.barella@intel.com>