### PR TITLE
Add tables to DB for BIOS, FW, Provisioning, and Harassers

### DIFF
--- a/pylib/Stages/Provisioning/WWulf3.py
+++ b/pylib/Stages/Provisioning/WWulf3.py
@@ -67,6 +67,18 @@ class WWulf3(ProvisionMTTStage):
         # parse what we were given against our defined options
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
+
+        mylog = {}
+        if cmds['target']:
+            mylog['target'] = cmds['target']
+        if cmds['image']:
+            mylog['image'] = cmds['image']
+        if cmds['controller']:
+            mylog['controller'] = cmds['controller']
+        if cmds['bootstrap']:
+            mylog['bootstrap'] = cmds['bootstrap']
+        log['provisioning'] = mylog
+
         # they had to at least give us one target node and controller
         try:
             if cmds['target'] is None:

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -191,6 +191,7 @@ class IUDatabase(ReporterMTTStage):
                                       logger.getLog(self._extract_param(logger, lg['section'], 'parent')),
                                       metadata,
                                       s, url, httpauth)
+
         if test_info is None:
             return None
 
@@ -211,8 +212,6 @@ class IUDatabase(ReporterMTTStage):
         # For now assume that we only had one test_build submitted
         # and all of the tests that follow are from that test_build
         common_data['test_build_id'] = test_info['test_build_id']
-
-        #import pdb; pdb.set_trace()
 
         for trun in (lg['testresults'] if 'testresults' in lg else [lg]):
             data = {}
@@ -312,7 +311,64 @@ class IUDatabase(ReporterMTTStage):
             # data['bandwidth_max'] = None
 
             # data['description'] = None
+            data['description'] = self._extract_param(logger, 'MTTDefaults', 'description')
             # data['environment'] = None
+            environment = {}
+            for lgentry in logger.getLog(None):
+                if 'environ' in lgentry:
+                    environment.update(lgentry['environ'])
+            data['environment'] = "\n".join([str(k) + "=" + str(v) for k,v in environment.items()])
+
+
+            # BIOS table
+            bios = {}
+            for lgentry in logger.getLog(None):
+                if 'bios' in lgentry:
+                    bios.update(lgentry['bios'])
+            try:
+                data['bios_nodelist'] = bios['nodelist']
+                data['bios_params'] = bios['params']
+                data['bios_values'] = bios['values']
+            except KeyError:
+                pass
+
+            # Firmware table (TODO: may want to grab whole cfg file)
+            firmware = {}
+            for lgentry in logger.getLog(None):
+                if 'firmware' in lgentry:
+                    firmware.update(lgentry['firmware'])
+            try:
+                data['flashupdt_cfg'] = firmware['flashupdt_cfg']
+                data['firmware_nodelist'] = firmware['nodelist']
+            except KeyError:
+                pass
+
+            # Provision table
+            provisioning = {}
+            for lgentry in logger.getLog(None):
+                if 'provisioning' in lgentry:
+                    provisioning.update(lgentry['provisioning'])
+            try:
+                data['targets'] = provisioning['target']
+                data['image'] = provisioning['image']
+                data['controllers'] = provisioning['controller']
+                data['bootstrap'] = provisioning['bootstrap']
+            except KeyError:
+                pass
+
+            # Harasser table
+            harasser = {}
+            for lgentry in logger.getLog(None):
+                if 'harasser' in lgentry:
+                    harasser.update(lgentry['harasser'])
+            try:
+                data['harasser_seed'] = harasser['seed']
+                data['inject_script'] = harasser['inject_script']
+                data['cleanup_script'] = harasser['cleanup_script']
+                data['check_script'] = harasser['check_script']
+            except KeyError:
+                pass
+
 
             try:
                 if options['merge_stdout_stderr']:
@@ -458,7 +514,13 @@ class IUDatabase(ReporterMTTStage):
 
         #data['exit_signal'] = None
         #data['description'] = None
+        data['description'] = self._extract_param(logger, 'MTTDefaults', 'description')
         #data['environment'] = None
+        environment = {}
+        for lgentry in logger.getLog(None):
+            if 'environ' in lgentry:
+                environment.update(lgentry['environ'])
+        data['environment'] = "\n".join([str(k) + "=" + str(v) for k,v in environment.items()])
 
         try:
             if options['merge_stdout_stderr']:
@@ -516,6 +578,7 @@ class IUDatabase(ReporterMTTStage):
         options = None
 
         # get the system profile
+
         profile = logger.getLog('Profile:Installed')['profile']
         if profile is None:
             print("Error: Failed to get 'profile'")
@@ -646,7 +709,13 @@ class IUDatabase(ReporterMTTStage):
 
         #data['exit_signal'] = None
         #data['description'] = None
+        data['description'] = self._extract_param(logger, 'MTTDefaults', 'description')
         #data['environment'] = None
+        environment = {}
+        for lgentry in logger.getLog(None):
+            if 'environ' in lgentry:
+                environment.update(lgentry['environ'])
+        data['environment'] = "\n".join([str(k) + "=" + str(v) for k,v in environment.items()])
 
         try:
             if options is not None and options['merge_stdout_stderr']:

--- a/pylib/Utilities/Environ.py
+++ b/pylib/Utilities/Environ.py
@@ -38,4 +38,5 @@ class Environ(BaseMTTUtility):
         for kvkey in kvkeys:
             os.environ[kvkey] = keyvals[kvkey]
         log['status'] = 0
+        log['environ'] = keyvals
         return

--- a/server/php/cherrypy/src/webapp/db_pgv3.py
+++ b/server/php/cherrypy/src/webapp/db_pgv3.py
@@ -603,8 +603,8 @@ class DatabaseV3():
         #
         # Insert this value
         #
-        #self._logger.debug(insert_stmt)
-        #self._logger.debug( ", ".join(str(x) for x in values) )
+        self._logger.debug(insert_stmt)
+        self._logger.debug( ", ".join(str(x) for x in values) )
         found_id = self._get_nextval( "%s_%s_seq" % (table, table_id))
 
         stmt_values.insert(0, found_id)
@@ -634,6 +634,7 @@ class DatabaseV3():
     def get_submit_id(self, metadata):
         self._logger.debug( "************** Submit ****************" )
 
+        
         fields = self.get_fields_for_submit()['required']
         values = []
         for field in fields:
@@ -1327,7 +1328,20 @@ class DatabaseV3():
                     "environment",
                     "merge_stdout_stderr",
                     "result_stdout",
-                    "result_stderr"]
+                    "result_stderr",
+                    "bios_nodelist",
+                    "bios_params",
+                    "bios_values",
+                    "flashupdt_cfg",
+                    "firmware_nodelist",
+                    "targets",
+                    "image",
+                    "controllers",
+                    "bootstrap",
+                    "harasser_seed",
+                    "inject_script",
+                    "cleanup_script",
+                    "check_script"]
 
         return {'required':fields, 'optional':optional}
 
@@ -1542,6 +1556,131 @@ class DatabaseV3():
             self._logger.debug("%s --- Processing: environment = %s" % (prefix, str(environment_id)) )
 
         #
+        # Process: cluster_checker
+        #
+        self._logger.debug("%s --- Processing: cluster_checker" % (prefix) )
+
+        clck_id = 0
+        if 'cluster_checker' not in entry.keys():
+            self._logger.debug("%s --- Processing: cluster_checker -- Skip" % (prefix) )
+        else:
+            fields = ["clck_results_file"]
+            values = []
+            for field in fields:
+                value = self._find_value(metadata, entry, field)
+                if value is None:
+                    return {"error_msg": "%s Missing field: %s" % (prefix, field)} 
+                values.append( value )
+
+            clck_id = self._select_insert("cluster_checker",
+                                          "clck_id",
+                                          fields, values)
+
+            self._logger.debug("%s --- Processing: cluster_checker = %s" % (prefix, str(clck_id)) )
+
+        #
+        # Process: bios
+        #
+        self._logger.debug("%s --- Processing: bios" % (prefix) )
+
+        bios_id = 0
+        if 'bios_nodelist' not in entry.keys() \
+                or 'bios_params' not in entry.keys() \
+                or 'bios_values' not in entry.keys():
+            self._logger.debug("%s --- Processing: bios -- Skip" % (prefix) )
+        else:
+            fields = ["bios_nodelist", "bios_params", "bios_values"]
+            values = []
+            for field in fields:
+                value = self._find_value(metadata, entry, field)
+                if value is None:
+                    return {"error_msg": "%s Missing field: %s" % (prefix, field)} 
+                values.append( value )
+
+            bios_id = self._select_insert("bios",
+                                          "bios_id",
+                                          fields, values)
+
+            self._logger.debug("%s --- Processing: bios = %s" % (prefix, str(bios_id)) )
+
+        #
+        # Process: firmware
+        #
+        self._logger.debug("%s --- Processing: firmware" % (prefix) )
+
+        firmware_id = 0
+        if 'flashupdt_cfg' not in entry.keys() or 'firmware_nodelist' not in entry.keys():
+            self._logger.debug("%s --- Processing: firmware -- Skip" % (prefix) )
+        else:
+            fields = ["flashupdt_cfg", "firmware_nodelist"]
+            values = []
+            for field in fields:
+                value = self._find_value(metadata, entry, field)
+                if value is None:
+                    return {"error_msg": "%s Missing field: %s" % (prefix, field)} 
+                values.append( value )
+
+            firmware_id = self._select_insert("firmware",
+                                              "firmware_id",
+                                              fields, values)
+
+            self._logger.debug("%s --- Processing: firmware = %s" % (prefix, str(firmware_id)) )
+
+        #
+        # Process: provision
+        #
+        self._logger.debug("%s --- Processing: provision" % (prefix) )
+
+        provision_id = 0
+        if 'targets' not in entry.keys() \
+                or 'image' not in entry.keys() \
+                or 'controllers' not in entry.keys() \
+                or 'bootstrap' not in entry.keys():
+            self._logger.debug("%s --- Processing: provision -- Skip" % (prefix) )
+        else:
+            fields = ["targets", "image", "controllers", "bootstrap"]
+            values = []
+            for field in fields:
+                value = self._find_value(metadata, entry, field)
+                if value is None:
+                    return {"error_msg": "%s Missing field: %s" % (prefix, field)} 
+                values.append( value )
+
+            provision_id = self._select_insert("provision",
+                                               "provision_id",
+                                               fields, values)
+
+            self._logger.debug("%s --- Processing: provision = %s" % (prefix, str(provision_id)) )
+
+        #
+        # Process: harasser
+        #
+        self._logger.debug("%s --- Processing: harasser" % (prefix) )
+
+        harasser_id = 0
+        if 'harasser_seed' not in entry.keys() \
+                or 'inject_script' not in entry.keys() \
+                or 'cleanup_script' not in entry.keys() \
+                or 'check_script' not in entry.keys():
+            self._logger.debug("%s --- Processing: harasser -- Skip" % (prefix) )
+        else:
+            fields = ["harasser_seed", "inject_script", "cleanup_script", "check_script"]
+            values = []
+            for field in fields:
+                value = self._find_value(metadata, entry, field)
+                if value is None:
+                    return {"error_msg": "%s Missing field: %s" % (prefix, field)} 
+                values.append( value )
+
+            harasser_id = self._select_insert("harasser",
+                                              "harasser_id",
+                                              fields, values)
+
+            self._logger.debug("%s --- Processing: harasser = %s" % (prefix, str(harasser_id)) )
+
+        # TODO: Add Process: firmware, provision, harasser too
+
+        #
         # Process: test_run
         #
         self._logger.debug("%s --- Processing: test_run" % (prefix) )
@@ -1561,7 +1700,12 @@ class DatabaseV3():
                   "test_run_command_id",
                   "description_id",
                   "environment_id",
-                  "result_message_id"]
+                  "result_message_id",
+                  "clck_id",
+                  "bios_id",
+                  "firmware_id",
+                  "provision_id",
+                  "harasser_id"]
 
         non_id_fields = ["start_timestamp",
                          "np",
@@ -1590,7 +1734,12 @@ class DatabaseV3():
                   test_run_command_id,
                   description_id,
                   environment_id,
-                  result_message_id]
+                  result_message_id,
+                  clck_id,
+                  bios_id,
+                  firmware_id,
+                  provision_id,
+                  harasser_id]
 
         for field in non_id_fields:
             # Try acommon alias for this field 'command'

--- a/server/sql/schemas-indexes.sql
+++ b/server/sql/schemas-indexes.sql
@@ -11,7 +11,7 @@
 -- Submit Table
 --
 --
-DROP INDEX idx_submit_http_username;
+DROP INDEX IF EXISTS idx_submit_http_username;
 CREATE INDEX idx_submit_http_username on submit (http_username);
 
 
@@ -43,7 +43,7 @@ CREATE INDEX idx_submit_http_username on submit (http_username);
 --
 -- Test Names Table
 --
-DROP INDEX idx_test_names_test_suite_id;
+DROP INDEX IF EXISTS idx_test_names_test_suite_id;
 CREATE INDEX idx_test_names_test_suite_id       ON test_names (test_suite_id);
 
 --

--- a/server/sql/schemas-reporter.sql
+++ b/server/sql/schemas-reporter.sql
@@ -5,7 +5,7 @@
 --
 -- Permalinks
 --
-DROP TABLE permalinks CASCADE;
+DROP TABLE IF EXISTS permalinks CASCADE;
 CREATE TABLE permalinks (
     permalink_id    serial PRIMARY KEY,
     permalink       text NOT NULL,

--- a/server/sql/schemas-stats.sql
+++ b/server/sql/schemas-stats.sql
@@ -7,7 +7,7 @@
 --
 -- Contribution/Coverage table
 --
-DROP TABLE mtt_stats_contrib CASCADE;
+DROP TABLE IF EXISTS mtt_stats_contrib CASCADE;
 CREATE TABLE mtt_stats_contrib (
     mtt_stats_contrib_id            serial,
 
@@ -83,7 +83,7 @@ CREATE TABLE mtt_stats_contrib (
 --
 -- Database Stats table
 --
-DROP TABLE mtt_stats_database CASCADE;
+DROP TABLE IF EXISTS mtt_stats_database CASCADE;
 CREATE TABLE mtt_stats_database (
     mtt_stats_database_id       serial,
 

--- a/server/sql/schemas-v3.sql
+++ b/server/sql/schemas-v3.sql
@@ -25,13 +25,13 @@
 --
 -- Serial number used for individual MTT runs
 --
-DROP SEQUENCE client_serial;
+DROP SEQUENCE IF EXISTS client_serial;
 CREATE SEQUENCE client_serial;
 
 --
 -- Cluster Table
 --
-DROP TABLE compute_cluster CASCADE;
+DROP TABLE IF EXISTS compute_cluster CASCADE;
 CREATE TABLE compute_cluster (
     compute_cluster_id  serial,
 
@@ -62,7 +62,7 @@ INSERT INTO compute_cluster VALUES ('0', 'undef', 'undef', 'undef', 'undef', 'un
 --
 -- Submit Table
 --
-DROP TABLE submit CASCADE;
+DROP TABLE IF EXISTS submit CASCADE;
 CREATE TABLE submit (
     submit_id           serial,
 
@@ -73,7 +73,7 @@ CREATE TABLE submit (
     -- Current Max: 8 chars
     http_username       varchar(16)  NOT NULL DEFAULT 'bogus',
     -- Current Max: 8 chars
-    mtt_client_version  varchar(16)          NOT NULL DEFAULT '',
+    mtt_client_version  varchar(16)  NOT NULL DEFAULT '',
 
     PRIMARY KEY (submit_id)
 );
@@ -83,7 +83,7 @@ INSERT INTO submit VALUES ('0', 'undef', 'undef', 'undef', 'undef');
 --
 -- Compiler Table
 --
-DROP TABLE compiler CASCADE;
+DROP TABLE IF EXISTS compiler CASCADE;
 CREATE TABLE compiler (
     compiler_id      serial,
 
@@ -105,7 +105,7 @@ INSERT INTO compiler VALUES ('0', 'undef', 'undef');
 --
 -- MPI Get Table
 --
-DROP TABLE mpi_get CASCADE;
+DROP TABLE IF EXISTS mpi_get CASCADE;
 CREATE TABLE mpi_get (
     mpi_get_id  serial,
 
@@ -127,7 +127,7 @@ INSERT INTO mpi_get VALUES ('0', 'undef', 'undef');
 --
 -- Results: Description Normalization table
 --
-DROP TABLE description CASCADE;
+DROP TABLE IF EXISTS description CASCADE;
 CREATE TABLE description (
     description_id  serial,
 
@@ -135,11 +135,15 @@ CREATE TABLE description (
 
     PRIMARY KEY (description_id)
 );
+--
+-- Add empty row to the description table
+--
+INSERT INTO description VALUES(0, '');
 
 --
 -- Results: Result Message Normalization table
 --
-DROP TABLE result_message CASCADE;
+DROP TABLE IF EXISTS result_message CASCADE;
 CREATE TABLE result_message (
     result_message_id  serial,
 
@@ -153,7 +157,7 @@ INSERT INTO result_message VALUES('0', 'undef');
 --
 -- Results: Environment Normalization table
 --
-DROP TABLE environment CASCADE;
+DROP TABLE IF EXISTS environment CASCADE;
 CREATE TABLE environment (
     environment_id  serial,
 
@@ -161,12 +165,16 @@ CREATE TABLE environment (
 
     PRIMARY KEY (environment_id)
 );
+--
+-- Add empty row to the environment table
+--
+INSERT INTO environment VALUES(0, '');
 
 
 --
 -- MPI Install Configure Argument Normalization table
 --
-DROP TABLE mpi_install_configure_args CASCADE;
+DROP TABLE IF EXISTS mpi_install_configure_args CASCADE;
 CREATE TABLE mpi_install_configure_args (
     mpi_install_configure_id        serial,
 
@@ -211,7 +219,7 @@ INSERT INTO mpi_install_configure_args VALUES ('0', DEFAULT, DEFAULT, DEFAULT, '
 --  get the total number of results in the database across the
 --  three partiion tables.
 --
-DROP TABLE results_fields CASCADE;
+DROP TABLE IF EXISTS results_fields CASCADE;
 CREATE TABLE results_fields (
     description_id      integer NOT NULL,
 
@@ -238,7 +246,7 @@ CREATE TABLE results_fields (
 --
 -- MPI Install Table
 --
-DROP TABLE mpi_install CASCADE;
+DROP TABLE IF EXISTS mpi_install CASCADE;
 CREATE TABLE mpi_install (
     mpi_install_id      serial,
 
@@ -285,7 +293,7 @@ INSERT INTO mpi_install
     mpi_install_configure_id, 
     mpi_install_id
    ) VALUES (
-    '1',
+    '0',
     TIMESTAMP '2006-11-01',
     '1',
     DEFAULT,
@@ -310,7 +318,7 @@ INSERT INTO mpi_install
 --
 -- Test Suite Table
 --
-DROP TABLE test_suites CASCADE;
+DROP TABLE IF EXISTS test_suites CASCADE;
 CREATE TABLE test_suites (
     test_suite_id       serial,
 
@@ -332,7 +340,7 @@ INSERT INTO test_suites VALUES ('0', 'undef', 'undef');
 -- Ind. Test Name Table
 -- NOTE: Test names are assumed to be unique in a test suite
 --
-DROP TABLE test_names CASCADE;
+DROP TABLE IF EXISTS test_names CASCADE;
 CREATE TABLE test_names (
     test_name_id        serial,
 
@@ -357,7 +365,7 @@ INSERT INTO test_names VALUES('0', '0', 'undef', 'undef');
 --
 -- Test Build Table
 --
-DROP TABLE test_build CASCADE;
+DROP TABLE IF EXISTS test_build CASCADE;
 CREATE TABLE test_build (
     test_build_id       serial,
 
@@ -415,7 +423,7 @@ INSERT INTO test_build
     test_build_compiler_id,
     test_build_id
    ) VALUES (
-    '1',
+    '0',
     TIMESTAMP '2006-11-01',
     '1',
     DEFAULT,
@@ -441,9 +449,72 @@ INSERT INTO test_build
    );
 
 --
+-- BIOS Table
+--
+DROP TABLE IF EXISTS bios CASCADE;
+CREATE TABLE bios (
+    bios_id     serial,
+    -- file with the bios switches; not an MTT .ini file.
+    bios_nodelist    text    NOT NULL DEFAULT '',
+    bios_params text    NOT NULL DEFAULT '',
+    bios_values text    NOT NULL DEFAULT '',
+
+    PRIMARY KEY (bios_id)
+
+);
+-- An invalid row in case we need it
+INSERT INTO bios VALUES ('0', '');
+
+--
+-- Firmware Table
+--
+DROP TABLE IF EXISTS firmware CASCADE;
+CREATE TABLE firmware (
+    firmware_id     serial,
+
+    flashupdt_cfg       text    NOT NULL DEFAULT '',
+    firmware_nodelist   text    NOT NULL DEFAULT '',
+
+    PRIMARY KEY (firmware_id)
+);
+-- An invalid row in case we need it
+INSERT INTO firmware VALUES ('0', '');
+
+--
+-- Provision Table
+--
+-- TODO: Is this table too specific to ipmi and warewulf? How to abstract?
+--
+DROP TABLE IF EXISTS provision CASCADE;
+CREATE TABLE provision (
+    provision_id    serial,
+    targets         text    NOT NULL DEFAULT '',
+    image           varchar(64),
+    controllers     text    NOT NULL DEFAULT '',
+    bootstrap       varchar(64),
+
+    PRIMARY KEY (provision_id)
+);
+INSERT INTO provision VALUES ('0', '', '', '', '');
+
+-- TODO: Create a Harasser table
+DROP TABLE IF EXISTS harasser CASCADE;
+CREATE TABLE harasser (
+    harasser_id     serial,
+
+    harasser_seed   integer,
+    inject_script   text    NOT NULL DEFAULT '',
+    cleanup_script  text    NOT NULL DEFAULT '',
+    check_script    text    NOT NULL DEFAULT '',
+
+    PRIMARY KEY (harasser_id)
+);
+INSERT INTO harasser VALUES ('0', '0', '', '', '');
+
+--
 -- Latency/Bandwidth Table
 --
-DROP TABLE latency_bandwidth CASCADE;
+DROP TABLE IF EXISTS latency_bandwidth CASCADE;
 CREATE TABLE latency_bandwidth (
     latency_bandwidth_id    serial,
 
@@ -461,7 +532,7 @@ CREATE TABLE latency_bandwidth (
 --
 -- Performance Table
 --
-DROP TABLE performance CASCADE;
+DROP TABLE IF EXISTS performance CASCADE;
 CREATE TABLE performance (
     performance_id          serial,
 
@@ -473,9 +544,22 @@ CREATE TABLE performance (
 );
 
 --
+-- Cluster Checker Table
+--
+DROP TABLE IF EXISTS cluster_checker CASCADE;
+CREATE TABLE cluster_checker (
+    clck_id             serial,
+    clck_results_file   text NOT NULL DEFAULT '',
+
+    PRIMARY KEY (clck_id)
+);
+-- An invalid row in case we need it
+INSERT INTO cluster_checker VALUES ('0', 'undef');
+
+--
 -- Interconnect Normalization table
 --
-DROP TABLE interconnects CASCADE;
+DROP TABLE IF EXISTS interconnects CASCADE;
 CREATE TABLE interconnects (
     interconnect_id         serial,
 
@@ -487,11 +571,11 @@ CREATE TABLE interconnects (
 --
 -- Test Run Command Network Normalization Table
 --
-DROP SEQUENCE test_run_network_id;
+DROP SEQUENCE IF EXISTS test_run_network_id;
 CREATE SEQUENCE test_run_network_id;
 
 
-DROP TABLE test_run_networks CASCADE;
+DROP TABLE IF EXISTS test_run_networks CASCADE;
 CREATE TABLE test_run_networks (
     -- This value should never be referenced!
     network_id              serial,
@@ -508,7 +592,7 @@ CREATE TABLE test_run_networks (
 --
 -- Test Run Command Normalization Table
 --
-DROP TABLE test_run_command CASCADE;
+DROP TABLE IF EXISTS test_run_command CASCADE;
 CREATE TABLE test_run_command (
     test_run_command_id          serial,
 
@@ -533,22 +617,27 @@ CREATE TABLE test_run_command (
 --  Use the create-partitions.pl script to generate the child table SQL commands
 --  Needed to link with this table.
 --
-DROP TABLE test_run CASCADE;
+DROP TABLE IF EXISTS test_run CASCADE;
 CREATE TABLE test_run (
     test_run_id         serial,
 
-    submit_id           integer NOT NULL DEFAULT '-38',
-    compute_cluster_id  integer NOT NULL DEFAULT '-38',
-    mpi_install_compiler_id         integer NOT NULL DEFAULT '-38',
-    mpi_get_id          integer NOT NULL DEFAULT '-38',
-    mpi_install_configure_id        integer NOT NULL DEFAULT '-38',
-    mpi_install_id      integer NOT NULL DEFAULT '-38',
-    test_suite_id       integer NOT NULL DEFAULT '-38',
-    test_build_compiler_id         integer NOT NULL DEFAULT '-38',
-    test_build_id       integer NOT NULL DEFAULT '-38',
-    test_name_id        integer NOT NULL DEFAULT '-38',
-    performance_id      integer  DEFAULT '-38',
-    test_run_command_id integer NOT NULL DEFAULT '-38',
+    submit_id                   integer NOT NULL DEFAULT '-38',
+    compute_cluster_id          integer NOT NULL DEFAULT '-38',
+    mpi_install_compiler_id     integer NOT NULL DEFAULT '-38',
+    mpi_get_id                  integer NOT NULL DEFAULT '-38',
+    mpi_install_configure_id    integer NOT NULL DEFAULT '-38',
+    mpi_install_id              integer NOT NULL DEFAULT '-38',
+    test_suite_id               integer NOT NULL DEFAULT '-38',
+    test_build_compiler_id      integer NOT NULL DEFAULT '-38',
+    test_build_id               integer NOT NULL DEFAULT '-38',
+    test_name_id                integer NOT NULL DEFAULT '-38',
+    performance_id              integer DEFAULT '-38',
+    clck_id                     integer DEFAULT '-38',
+    test_run_command_id         integer NOT NULL DEFAULT '-38',
+    bios_id                     integer DEFAULT '-38',
+    firmware_id                 integer DEFAULT '-38',
+    provision_id                integer DEFAULT '-38',
+    harasser_id                 integer DEFAULT '-38',
 
     np                  smallint NOT NULL DEFAULT '-38',
     full_command        text NOT NULL DEFAULT 'bogus',
@@ -568,6 +657,7 @@ CREATE TABLE test_run (
     -- PARTITION/FK PROBLEM: FOREIGN KEY (test_build_id) REFERENCES test_build(test_build_id),
     FOREIGN KEY (test_name_id) REFERENCES test_names(test_name_id),
     FOREIGN KEY (performance_id) REFERENCES performance(performance_id),
+    FOREIGN KEY (clck_id) REFERENCES cluster_checker(clck_id),
     FOREIGN KEY (test_run_command_id) REFERENCES test_run_command(test_run_command_id),
     FOREIGN KEY (description_id) REFERENCES description(description_id),
     FOREIGN KEY (environment_id) REFERENCES environment(environment_id),
@@ -582,7 +672,7 @@ CREATE TABLE test_run (
 --
 -- Cluster Table
 --
-DROP TABLE temp_conv_compute_cluster CASCADE;
+DROP TABLE IF EXISTS temp_conv_compute_cluster CASCADE;
 CREATE TABLE temp_conv_compute_cluster (
     new_compute_cluster_id  integer NOT NULL,
     old_compute_cluster_id  integer NOT NULL
@@ -592,7 +682,7 @@ CREATE INDEX temp_conv_compute_cluster_idx ON temp_conv_compute_cluster (old_com
 --
 -- Submit Table
 --
-DROP TABLE temp_conv_submit CASCADE;
+DROP TABLE IF EXISTS temp_conv_submit CASCADE;
 CREATE TABLE temp_conv_submit (
     new_submit_id  integer NOT NULL,
     old_submit_id  integer NOT NULL
@@ -602,7 +692,7 @@ CREATE INDEX temp_conv_submit_idx ON temp_conv_submit (old_submit_id);
 --
 -- Compiler Table
 --
-DROP TABLE temp_conv_compiler CASCADE;
+DROP TABLE IF EXISTS temp_conv_compiler CASCADE;
 CREATE TABLE temp_conv_compiler (
     new_compiler_id  integer NOT NULL,
     old_compiler_id  integer NOT NULL
@@ -612,7 +702,7 @@ CREATE INDEX temp_conv_compiler_idx ON temp_conv_compiler (old_compiler_id);
 --
 -- Mpi_Get Table
 --
-DROP TABLE temp_conv_mpi_get CASCADE;
+DROP TABLE IF EXISTS temp_conv_mpi_get CASCADE;
 CREATE TABLE temp_conv_mpi_get (
     new_mpi_get_id  integer NOT NULL,
     old_mpi_get_id  integer NOT NULL
@@ -622,7 +712,7 @@ CREATE INDEX temp_conv_mpi_get_idx ON temp_conv_mpi_get (old_mpi_get_id);
 --
 -- Latency_Bandwidth Table
 --
-DROP TABLE temp_conv_latency_bandwidth CASCADE;
+DROP TABLE IF EXISTS temp_conv_latency_bandwidth CASCADE;
 CREATE TABLE temp_conv_latency_bandwidth (
     new_latency_bandwidth_id  integer NOT NULL,
     old_latency_bandwidth_id  integer NOT NULL
@@ -632,7 +722,7 @@ CREATE INDEX temp_conv_latency_bandwidth_idx ON temp_conv_latency_bandwidth (old
 --
 -- MPI Install
 --
-DROP TABLE temp_conv_mpi_install CASCADE;
+DROP TABLE IF EXISTS temp_conv_mpi_install CASCADE;
 CREATE TABLE temp_conv_mpi_install (
     new_mpi_install_id  integer NOT NULL,
 
@@ -645,7 +735,7 @@ CREATE INDEX temp_conv_mpi_install_idx ON temp_conv_mpi_install (old_results_id)
 --
 -- Test Build
 --
-DROP TABLE temp_conv_test_build CASCADE;
+DROP TABLE IF EXISTS temp_conv_test_build CASCADE;
 CREATE TABLE temp_conv_test_build (
     new_test_build_id  integer NOT NULL,
 
@@ -658,7 +748,7 @@ CREATE INDEX temp_conv_test_build_idx ON temp_conv_test_build (old_results_id);
 --
 -- Test Run
 --
-DROP TABLE temp_conv_test_run CASCADE;
+DROP TABLE IF EXISTS temp_conv_test_run CASCADE;
 CREATE TABLE temp_conv_test_run (
     new_test_run_id  integer NOT NULL,
 
@@ -675,16 +765,6 @@ CREATE INDEX temp_conv_test_run_idx ON temp_conv_test_run (old_results_id);
 --
 INSERT INTO latency_bandwidth VALUES(0);
 INSERT INTO performance VALUES(0,0);
-
---
--- Add empty row to the description table
---
-INSERT INTO description VALUES(0, '');
-
---
--- Add empty row to the environment table
---
-INSERT INTO environment VALUES(0, '');
 
 --
 -- Add empty row to test_run_command as a placeholder

--- a/server/sql/summary/summary_tables.sql
+++ b/server/sql/summary/summary_tables.sql
@@ -1,9 +1,9 @@
-DROP TABLE summary_mpi_install;
-DROP TABLE summary_test_build;
-DROP TABLE summary_test_run;
-DROP TABLE summary_base;
+DROP TABLE IF EXISTS summary_mpi_install;
+DROP TABLE IF EXISTS summary_test_build;
+DROP TABLE IF EXISTS summary_test_run;
+DROP TABLE IF EXISTS summary_base;
 
-DROP TABLE summary_range;
+DROP TABLE IF EXISTS summary_range;
 
 --
 -- A table to quickly lookup the earliest date for which there is summary data.

--- a/server/sql/summary/summary_trigger.sql
+++ b/server/sql/summary/summary_trigger.sql
@@ -1,6 +1,7 @@
 --
 -- We need this language for the triggers
 --
+-- CREATE OR REPLACE LANGUAGE plpgsql;
 CREATE LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION update_summary_table() RETURNS TRIGGER AS $update_summary_table$

--- a/server/sql/support/create-partitions-test-run.pl
+++ b/server/sql/support/create-partitions-test-run.pl
@@ -78,6 +78,10 @@ foreach $month (@month_array) {
     print "    FOREIGN KEY (test_build_compiler_id) REFERENCES compiler(compiler_id),\n";
     print "    -- PARTITION/FK PROBLEM: FOREIGN KEY (test_build_id) REFERENCES test_build(test_build_id),\n";
     print "    FOREIGN KEY (test_name_id) REFERENCES test_names(test_name_id),\n";
+    print "    FOREIGN KEY (bios_id) REFERENCES bios(bios_id),\n";
+    print "    FOREIGN KEY (firmware_id) REFERENCES firmware(firmware_id),\n";
+    print "    FOREIGN KEY (provision_id) REFERENCES provision(provision_id),\n";
+    print "    FOREIGN KEY (harasser_id) REFERENCES harasser(harasser_id),\n";
     print "    FOREIGN KEY (performance_id) REFERENCES performance(performance_id),\n";
     print "    FOREIGN KEY (test_run_command_id) REFERENCES test_run_command(test_run_command_id),\n";
     print "    FOREIGN KEY (description_id) REFERENCES description(description_id),\n";
@@ -133,6 +137,10 @@ foreach $month (@month_array) {
     print "         test_build_compiler_id,\n";
     print "         test_build_id,\n";
     print "         test_name_id,\n";
+    print "         bios_id,\n";
+    print "         firmware_id,\n";
+    print "         provision_id,\n";
+    print "         harasser_id,\n";
     print "         performance_id,\n";
     print "         test_run_command_id,\n";
     print "         np,\n";
@@ -164,6 +172,10 @@ foreach $month (@month_array) {
     print "              NEW.test_build_compiler_id,\n";
     print "              NEW.test_build_id,\n";
     print "              NEW.test_name_id,\n";
+    print "              NEW.bios_id,\n";
+    print "              NEW.firmware_id,\n";
+    print "              NEW.provision_id,\n";
+    print "              NEW.harasser_id,\n";
     print "              NEW.performance_id,\n";
     print "              NEW.test_run_command_id,\n";
     print "              NEW.np,\n";


### PR DESCRIPTION
WARNING: I am unsure if this pull request will break the Perl client since it adds to the MTT DB SQL schema.

This pull request is a good example of the effort it takes to make database changes while keeping compatibility with the python client.

Tables are added for the BIOS, FW, and Provisioning stages, along with Harasser table, and are connected to the Test Run table, since each of these only affect the test while it is running.
* BIOS, FW, Provisioning, and Harassers affect the compute nodes which are only accessed when the test is running

There is no Harasser stage, and Harasser framework is not developed yet, however I included it in the DB anyways.

Signed-off-by: Richard Barella <richard.t.barella@intel.com>