### PR TITLE
Fixes #523 - Copytree now creates dst directory if it doesn't exist

### DIFF
--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -60,6 +60,7 @@ class Copytree(BaseMTTUtility):
             # Cleanup the target directory if it exists
             if os.path.exists(dst):
                 shutil.rmtree(dst)
+            os.mkdir(dst)
             for srcpath in cmds['src'].split(','):
                 srcpath = srcpath.strip()
                 distutils.dir_util.copy_tree(srcpath, dst)


### PR DESCRIPTION
Combinatorial executor doesn't create the destination directory beforehand, and "distutils" library expects destination directory to already exist. Therefore, Copytree must make sure it exists, and thus my change ensures the destination directory's existance.

Signed-off-by: Richard Barella <richard.t.barella@intel.com>