### PR TITLE
Colon ":" is now Underscore "_" in path

### DIFF
--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -52,7 +52,7 @@ class Copytree(BaseMTTUtility):
             log['stderr'] = "Src directory not specified"
             return
         # define the dst directory
-        dst = os.path.join(testDef.options['scratchdir'], log['section'])
+        dst = os.path.join(testDef.options['scratchdir'], log['section'].replace(":","_"))
         # record the location
         log['location'] = dst
         # perform the copy


### PR DESCRIPTION
This is the fix that addresses @jsquyres concerns in https://github.com/open-mpi/mtt/pull/518

Copytree plugin will write new paths with underscores instead of colons

Stage names have colons in them, and when writing directories with colons, makefiles in those directories have an issue deciphering their path. This commit fixes the problem by replacing ":" with "_" in new directory.

Signed-off-by: Richard Barella <richard.t.barella@intel.com>