### PR TITLE
Fixes #526: Combinatorial now doesn't try to write ENV into temp INI files

### DIFF
--- a/pylib/Tools/Executor/combinatorial.py
+++ b/pylib/Tools/Executor/combinatorial.py
@@ -72,6 +72,8 @@ class CombinatorialEx(ExecutorMTTTool):
         writeOption.optionxform = str
         # Sort base .ini sections and write to temp files 
         for section in self.baseIniFile.sections():
+            if section == "ENV":
+                continue
             if section.startswith("SKIP") or section.startswith("skip"):
                 # users often want to temporarily ignore a section
                 # of their test definition file, but don't want to


### PR DESCRIPTION
By skipping ENV section in combinatorial executor, this section (which is created dynamically) is not written to the temporary INI files that is used by the combinatorial executor. Before this fix, an error occurred where combinatorial executor tried to interpolate ${} syntax from environment variables while writing to INI files.

Signed-off-by: Richard Barella <richard.t.barella@intel.com>