### PR TITLE
Whatami: Adding Amazon Linux support

### DIFF
--- a/client/whatami/whatami
+++ b/client/whatami/whatami
@@ -222,6 +222,13 @@ get_linux_type()
                         #distro=${distro_brand}_${distro_version}
                         distro=${distro_brand}
 
+                # Welcome to Amazon Linux (x86-64) - Kernel \r (\l)
+                elif [ -f /etc/os-release ] && [ -n "`egrep 'Amazon Linux AMI' /etc/os-release`" ]; then
+                        source /etc/os-release
+                        distro_brand="${ID}"
+                        distro_version="${VERSION}"
+                        distro=${distro_brand}_${distro_version}
+
                 elif [ -f /etc/redhat-release -a -n "`egrep 'Red Hat Enterprise Linux ([a-zA-Z]+) release [0-9]*' /etc/redhat-release`" ]; then
                         distro_brand=rhel
                         distro_version=`grep 'Red Hat' /etc/redhat-release | sed -e 's/Red Hat Enterprise Linux \([a-zA-Z]*\) release \([0-9]*\).*/\2/' `


### PR DESCRIPTION
With this change MTT can recognize 'Amazon-Linux machine (AWS)' and able
to fill hardware/OS fields while MTT reporting

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

Tested: https://mtt.open-mpi.org/
<AWS Ec2 machine>
whatami -o
whatami -t: linux-amzn_2016.03-x86_64
whatami -n: Linux
whatami -r: Linux 4.4.11-23.53.amzn1.x86_64
whatami -m: x86_64
whatami -a: linux-amzn_2016.03-x86_64 x86_64 Linux 4.4.11-23.53.amzn1.x86_64
whatami -v: whatami 2008.11.06
whatami --version: whatami 2008.11.06
whatami -h: whatami 2008.11.06

<Local machine>
whatami -o
whatami -t: linux-rhel5-x86_64
whatami -n: Linux
whatami -r: Linux 3.2.45-0.6.acc.624.45.283.amzn1acc.x86_64
whatami -m: x86_64
whatami -a: linux-rhel5-x86_64 x86_64 Linux 3.2.45-0.6.acc.624.45.283.amzn1acc.x86_64
whatami -v: whatami 2008.11.06
whatami --version: whatami 2008.11.06
whatami -h: whatami 2008.11.06