### PR TITLE
Fixes #541: nodelist implemented for SLURM parsing

### DIFF
--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -433,8 +433,14 @@ class SLURM(LauncherMTTTool):
                 log['np'] = str(cmds['options'].split('--ntasks=')[1].split(' ')[0])
             elif '-N ' in cmds['options']:
                 log['np'] = str(cmds['options'].split('-N ')[1].split(' ')[0])
-            else: #'--nodes=' in cmds['options']
+            elif '--nodes=' in cmds['options']:
                 log['np'] = str(cmds['options'].split('--nodes=')[1].split(' ')[0])
+            elif '-w ' in cmds['options']:
+                log['np'] = str(len(cmds['options'].split('-w ')[1].split(' ')[0].split(',')))
+            elif '--nodelist=' in cmds['options']:
+                log['np'] = str(len(cmds['options'].split('--nodelist=')[1].split(' ')[0].split(',')))
+            else:
+                log['np'] = None
         else:
             try:
                 log['np'] = cmds['np']


### PR DESCRIPTION
'nodelist=' and '-w' switches were not parsed in SLURM plugin, and SLURM was expecting a different way of specifying nodes used. This caused an error in the parsing script.

Issue fixed by implementing nodelist and -w for SLURM parsing.