### PR TITLE
MTT console: execution directiory is now configurable, LANG set to POSIX

### DIFF
--- a/tests/jenkins/Dockerfile
+++ b/tests/jenkins/Dockerfile
@@ -62,6 +62,7 @@ RUN perl -pi -e "s/SLAVE_NODE_NAME_VAR/$slave_node_name/g" $JENKINS_HOME/nodes/$
 RUN perl -pi -e "s/SLAVE_NODE_NUM_EXECUTORS_VAR/$slave_node_num_executors/g" $JENKINS_HOME/nodes/$slave_node_name/config.xml
 RUN perl -pi -e "s/SLAVE_NODE_IP_ADDR_VAR/$slave_node_ip_addr/g" $JENKINS_HOME/nodes/$slave_node_name/config.xml
 RUN perl -pi -e "s/SLAVE_NODE_NUM_COMPUTES_VAR/$slave_node_num_computes/g" $JENKINS_HOME/nodes/$slave_node_name/config.xml
+RUN perl -pi -e "s/SLAVE_NODE_EXEC_DIR_VAR/${slave_node_exec_dir}/g" $JENKINS_HOME/nodes/$slave_node_name/config.xml
 # $slave_node_name
 
 # Lockable resources configuration step

--- a/tests/jenkins/config.xml
+++ b/tests/jenkins/config.xml
@@ -60,5 +60,19 @@
   <slaveAgentPort>50000</slaveAgentPort>
   <label></label>
   <nodeProperties/>
-  <globalNodeProperties/>
+  <globalNodeProperties>
+    <hudson.slaves.EnvironmentVariablesNodeProperty>
+      <envVars serialization="custom">
+        <unserializable-parents/>
+        <tree-map>
+          <default>
+            <comparator class="hudson.util.CaseInsensitiveComparator"/>
+          </default>
+          <int>1</int>
+          <string>LANG</string>
+          <string>POSIX</string>
+        </tree-map>
+      </envVars>
+    </hudson.slaves.EnvironmentVariablesNodeProperty>
+  </globalNodeProperties>
 </hudson>

--- a/tests/jenkins/nodes/SLAVE_NODE_NAME_VAR/config.xml
+++ b/tests/jenkins/nodes/SLAVE_NODE_NAME_VAR/config.xml
@@ -2,7 +2,7 @@
 <slave>
   <name>SLAVE_NODE_NAME_VAR</name>
   <description></description>
-  <remoteFS>/var/jenkins</remoteFS>
+  <remoteFS>SLAVE_NODE_EXEC_DIR_VAR</remoteFS>
   <numExecutors>SLAVE_NODE_NUM_EXECUTORS_VAR</numExecutors>
   <mode>EXCLUSIVE</mode>
   <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
@@ -22,9 +22,11 @@
           <default>
             <comparator class="hudson.util.CaseInsensitiveComparator"/>
           </default>
-          <int>3</int>
+          <int>2</int>
           <string>NUM_COMPUTES_AVAIL</string>
           <string>SLAVE_NODE_NUM_COMPUTES_VAR</string>
+          <string>LANG</string>
+          <string>POSIX</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>


### PR DESCRIPTION
Before execution directory was hardcoded to an incorrect value, which caused permission issues.

Also, LANG before was set to UTF-8 by default which caused issues with some stderr output.

This pull request fixes those issues.