### PR TITLE
Moved Shell plugin to use shlex parser for command args.  Enables cor…

### DIFF
--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -13,6 +13,7 @@ import os
 import re
 import string
 import sys
+import shlex
 from BuildMTTTool import *
 
 ## @addtogroup Tools
@@ -248,7 +249,7 @@ class Autotools(BuildMTTTool):
         # if they gave us any configure args, add them
         try:
             if cmds['configure_options'] is not None:
-                args = cmds['configure_options'].split()
+                args = shlex.split(cmds['configure_options'])
                 for arg in args:
                     cfgargs.append(arg.strip())
         except KeyError:

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 import os
 import re
+import shlex
 from BuildMTTTool import *
 
 ## @addtogroup Tools
@@ -239,7 +240,8 @@ class Shell(BuildMTTTool):
         # now move to the package location
         os.chdir(location)
         # execute the specified command
-        cfgargs = cmds['command'].split()
+        # Use shlex.split() for correct tokenization for args
+        cfgargs = shlex.split(cmds['command'])
 
         if 'TestRun' in log['section'].split(":")[0]:
             harass_exec_ids = testDef.harasser.start(log, testDef)


### PR DESCRIPTION
…rect command parsing with multiple shell commands.

For example, command = sh -c "which mpirun; which mpirun".

Signed-off-by: Noah van Dresser <daniel.n.van.dresser@intel.com>