### PR TITLE
Fixes 547: Copytree now reloads disutils.dir_util before copying directory

### DIFF
--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -63,6 +63,7 @@ class Copytree(BaseMTTUtility):
             os.mkdir(dst)
             for srcpath in cmds['src'].split(','):
                 srcpath = srcpath.strip()
+                reload(distutils.dir_util)
                 distutils.dir_util.copy_tree(srcpath, dst)
             log['status'] = 0
         except (os.error, shutil.Error) as e:


### PR DESCRIPTION
This is done to clear the cache so that distutils.dir_util doesn't assume the same directory structure from last time things were copied.