### PR TITLE
Added test_list to ompi_hello_world.ini so it doesn't conflict with o…

### DIFF
--- a/samples/python/ompi_hello_world.ini
+++ b/samples/python/ompi_hello_world.ini
@@ -69,6 +69,7 @@ options = -N 4
 plugin = SLURM
 parent = TestBuild:HelloWorld
 save_stdout_on_pass = 1
+test_list = mpi_hello_world
 
 #======================================================================
 # Reporter phase


### PR DESCRIPTION
ompi_hello_world.ini was copying harasser shell scripts and then running them. To avoid this, "test_list" was defined in ompi_hello_world.ini so that it will only execute what it built.