### PR TITLE
Updated build plugins to set LIBRARY_PATH and CPATH from middleware.

### DIFF
--- a/pylib/Stages/TestBuild/DefaultTestBuild.py
+++ b/pylib/Stages/TestBuild/DefaultTestBuild.py
@@ -99,10 +99,10 @@ class DefaultTestBuild(TestBuildMTTStage):
                             os.environ['PATH'] = newpath
                             # prepend the libdir path as well
                             try:
-                                oldlibpath = os.environ['LD_LIBRARY_PATH']
-                                pieces = oldlibpath.split(':')
+                                oldldlibpath = os.environ['LD_LIBRARY_PATH']
+                                pieces = oldldlibpath.split(':')
                             except KeyError:
-                                oldlibpath = ""
+                                oldldlibpath = ""
                                 pieces = []
                             bindir = os.path.join(midlog['location'], "lib")
                             pieces.insert(0, bindir)
@@ -146,5 +146,5 @@ class DefaultTestBuild(TestBuildMTTStage):
         # if we added middleware to the paths, remove it
         if midpath:
             os.environ['PATH'] = oldbinpath
-            os.environ['LD_LIBRARY_PATH'] = oldlibpath
+            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
         return

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -142,9 +142,31 @@ class Shell(BuildMTTTool):
                             pieces.insert(0, bindir)
                             newpath = ":".join(pieces)
                             os.environ['PATH'] = newpath
-                            # prepend the libdir path as well
+                            # prepend the loadable lib path
                             try:
-                                oldlibpath = os.environ['LD_LIBRARY_PATH']
+                                oldldlibpath = os.environ['LD_LIBRARY_PATH']
+                                pieces = oldldlibpath.split(':')
+                            except KeyError:
+                                oldldlibpath = ""
+                                pieces = []
+                            bindir = os.path.join(midlog['location'], "lib")
+                            pieces.insert(0, bindir)
+                            newpath = ":".join(pieces)
+                            os.environ['LD_LIBRARY_PATH'] = newpath
+                            # prepend the include path 
+                            try:
+                                oldcpath = os.environ['CPATH']
+                                pieces = oldcpath.split(':')
+                            except KeyError:
+                                oldcpath = ""
+                                pieces = []
+                            bindir = os.path.join(midlog['location'], "include")
+                            pieces.insert(0, bindir)
+                            newpath = ":".join(pieces)
+                            os.environ['CPATH'] = newpath
+                            # prepend the lib path 
+                            try:
+                                oldlibpath = os.environ['LIBRARY_PATH']
                                 pieces = oldlibpath.split(':')
                             except KeyError:
                                 oldlibpath = ""
@@ -152,7 +174,8 @@ class Shell(BuildMTTTool):
                             bindir = os.path.join(midlog['location'], "lib")
                             pieces.insert(0, bindir)
                             newpath = ":".join(pieces)
-                            os.environ['LD_LIBRARY_PATH'] = newpath
+                            os.environ['LIBRARY_PATH'] = newpath
+
                             # mark that this was done
                             midpath = True
                     except KeyError:
@@ -297,7 +320,9 @@ class Shell(BuildMTTTool):
         # if we added middleware to the paths, remove it
         if midpath:
             os.environ['PATH'] = oldbinpath
-            os.environ['LD_LIBRARY_PATH'] = oldlibpath
+            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
+            os.environ['CPATH'] = oldcpath
+            os.environ['LIBRARY_PATH'] = oldlibpath
 
         # return to original location
         os.chdir(cwd)

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -169,19 +169,30 @@ class ALPS(LauncherMTTTool):
                         try:
                             if midlog['location'] is not None:
                                 # prepend that location to our paths
-                                path = os.environ['PATH']
-                                pieces = path.split(':')
+                                try:
+                                    oldbinpath = os.environ['PATH']
+                                    pieces = oldbinpath.split(':')
+                                except KeyError:
+                                    oldbinpath = ""
+                                    pieces = []
                                 bindir = os.path.join(midlog['location'], "bin")
                                 pieces.insert(0, bindir)
                                 newpath = ":".join(pieces)
                                 os.environ['PATH'] = newpath
-                                # prepend the libdir path as well
-                                path = os.environ['LD_LIBRARY_PATH']
-                                pieces = path.split(':')
+                                # prepend the loadable lib path
+                                try:
+                                    oldldlibpath = os.environ['LD_LIBRARY_PATH']
+                                    pieces = oldldlibpath.split(':')
+                                except KeyError:
+                                    oldldlibpath = ""
+                                    pieces = []
                                 bindir = os.path.join(midlog['location'], "lib")
                                 pieces.insert(0, bindir)
                                 newpath = ":".join(pieces)
                                 os.environ['LD_LIBRARY_PATH'] = newpath
+    
+                                # mark that this was done
+                                midpath = True
                         except KeyError:
                             # if it was already installed, then no location would be provided
                             pass
@@ -477,6 +488,11 @@ class ALPS(LauncherMTTTool):
                 log['stderr'] = stderr
                 os.chdir(cwd)
                 return
+
+        # if we added middleware to the paths, remove it
+        if midpath:
+            os.environ['PATH'] = oldbinpath
+            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
 
         os.chdir(cwd)
         return

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -150,24 +150,29 @@ class OpenMPI(LauncherMTTTool):
                             if midlog['location'] is not None:
                                 # prepend that location to our paths
                                 try:
-                                    path = os.environ['PATH']
-                                    pieces = path.split(':')
+                                    oldbinpath = os.environ['PATH']
+                                    pieces = oldbinpath.split(':')
                                 except KeyError:
+                                    oldbinpath = ""
                                     pieces = []
                                 bindir = os.path.join(midlog['location'], "bin")
                                 pieces.insert(0, bindir)
                                 newpath = ":".join(pieces)
                                 os.environ['PATH'] = newpath
-                                # prepend the libdir path as well
+                                # prepend the loadable lib path
                                 try:
-                                    path = os.environ['LD_LIBRARY_PATH']
-                                    pieces = path.split(':')
+                                    oldldlibpath = os.environ['LD_LIBRARY_PATH']
+                                    pieces = oldldlibpath.split(':')
                                 except KeyError:
+                                    oldldlibpath = ""
                                     pieces = []
                                 bindir = os.path.join(midlog['location'], "lib")
                                 pieces.insert(0, bindir)
                                 newpath = ":".join(pieces)
                                 os.environ['LD_LIBRARY_PATH'] = newpath
+
+                                # mark that this was done
+                                midpath = True
                         except KeyError:
                             # if it was already installed, then no location would be provided
                             pass
@@ -381,5 +386,11 @@ class OpenMPI(LauncherMTTTool):
             log['np'] = cmds['np']
         except KeyError:
             log['np'] = None
+
+        # if we added middleware to the paths, remove it
+        if midpath:
+            os.environ['PATH'] = oldbinpath
+            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
+
         os.chdir(cwd)
         return

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -171,19 +171,30 @@ class SLURM(LauncherMTTTool):
                         try:
                             if midlog['location'] is not None:
                                 # prepend that location to our paths
-                                path = os.environ['PATH']
-                                pieces = path.split(':')
+                                try:
+                                    oldbinpath = os.environ['PATH']
+                                    pieces = oldbinpath.split(':')
+                                except KeyError:
+                                    oldbinpath = ""
+                                    pieces = []
                                 bindir = os.path.join(midlog['location'], "bin")
                                 pieces.insert(0, bindir)
                                 newpath = ":".join(pieces)
                                 os.environ['PATH'] = newpath
-                                # prepend the libdir path as well
-                                path = os.environ['LD_LIBRARY_PATH']
-                                pieces = path.split(':')
+                                # prepend the loadable lib path
+                                try:
+                                    oldldlibpath = os.environ['LD_LIBRARY_PATH']
+                                    pieces = oldldlibpath.split(':')
+                                except KeyError:
+                                    oldldlibpath = ""
+                                    pieces = []
                                 bindir = os.path.join(midlog['location'], "lib")
                                 pieces.insert(0, bindir)
                                 newpath = ":".join(pieces)
                                 os.environ['LD_LIBRARY_PATH'] = newpath
+
+                                # mark that this was done
+                                midpath = True
                         except KeyError:
                             # if it was already installed, then no location would be provided
                             pass
@@ -480,6 +491,10 @@ class SLURM(LauncherMTTTool):
                 log['stderr'] = stderr
                 os.chdir(cwd)
                 return
+        # if we added middleware to the paths, remove it
+        if midpath:
+            os.environ['PATH'] = oldbinpath
+            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
 
         os.chdir(cwd)
         return


### PR DESCRIPTION
Cleaned up launcher plugins to have consistent LD_LIBRARY_PATH and PATH usage.

Signed-off-by: Noah van Dresser <daniel.n.van.dresser@intel.com>