### PR TITLE
Added ASIS functionality for both Shell plugin and Copytree plugin

### DIFF
--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -50,6 +50,7 @@ class Shell(BuildMTTTool):
         self.options['fail_returncode'] = (None, "Specifies the expected failure returncode of this test")
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
+        self.options['binary'] = (None, "Specifies name of binary being built. This is used with \"ASIS\" keyword to determine whether to do anything.")
         return
 
     def activate(self):
@@ -122,6 +123,16 @@ class Shell(BuildMTTTool):
             # just log success and return
             log['status'] = 0
             return
+
+        try:
+            if cmds['asis'] and os.path.exists(os.path.join(location,cmds['binary'])) \
+                            and os.path.isfile(os.path.join(location,cmds['binary'])):
+                testDef.logger.verbose_print("As-Is binary " + os.path.join(location,cmds['binary']) + " exists and is a file")
+                log['location'] = location
+                log['status'] = 0
+                return
+        except KeyError:
+            pass
 
         # check if we need to point to middleware
         midpath = False

--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -55,6 +55,14 @@ class Copytree(BaseMTTUtility):
         dst = os.path.join(testDef.options['scratchdir'], log['section'].replace(":","_"))
         # record the location
         log['location'] = dst
+        # Check if already exists to skip if ASIS is set
+        try:
+            if cmds['asis'] and os.path.exists(dst) and os.path.isdir(dst):
+                testDef.logger.verbose_print("As-Is location " + dst + " exists and is a directory")
+                log['status'] = 0
+                return
+        except KeyError:
+            pass
         # perform the copy
         try:
             # Cleanup the target directory if it exists


### PR DESCRIPTION
ASIS was missing from two plugins, which made people think ASIS was broken. I implemented ASIS for both Shell plugin and Copytree plugin.

Shell plugin requires the created binary to be specified for ASIS to work. ASIS will skip execution if binary already exists.