### PR TITLE
IPMITool: futurize it

### DIFF
--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -24,6 +24,8 @@ from yapsy.PluginManager import PluginManager
 import datetime
 from distutils.spawn import find_executable
 
+is_py2 = sys.version[0] == '2'
+
 # The Test Definition class is mostly a storage construct
 # to make it easier when passing values across stages and
 # tools.
@@ -83,8 +85,6 @@ class TestDef(object):
         elif type(opt) is bool:
             if type(inval) is bool:
                 return 0, inval
-            elif type(inval) is unicode:
-                return 0, int(inval)
             elif type(inval) is str:
                 if inval.lower() in ['true', '1', 't', 'y', 'yes']:
                     return 0, True
@@ -95,6 +95,8 @@ class TestDef(object):
                     return 0, False
                 else:
                     return 0, True
+            elif is_py2 and type(inval) is unicode:
+                return 0, int(inval)
             else:
                 # unknown conversion required
                 print("Unknown conversion required for " + inval)

--- a/pylib/Tools/CNC/IPMITool.py
+++ b/pylib/Tools/CNC/IPMITool.py
@@ -10,7 +10,10 @@
 
 import os
 import sys
-import Queue
+try:
+    from Queue import *
+except:
+    from queue import *
 import threading
 from CNCMTTTool import *
 

--- a/pylib/Utilities/Environ.py
+++ b/pylib/Utilities/Environ.py
@@ -8,6 +8,7 @@
 # $HEADER$
 #
 
+from __future__ import print_function
 import shutil
 import os
 from BaseMTTUtility import *
@@ -27,7 +28,7 @@ class Environ(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print prefix + line
+            print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):


### PR DESCRIPTION
the IPMITool wasn't working with python3.  Change
so that, provided future is installed with python,
it can work both with python 2 and 3.  We already
require future for other parts of pyclient.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>