### PR TITLE
MTT now exits with error message when no INI is inputted

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -233,7 +233,7 @@ testDef.printInfo()
 
 # if they didn't specify any files, then there is nothing
 # for us to do
-if not args.ini_files:
+if not args.ini_files or not args.ini_files[0]:
     sys.exit('MTT requires at least one test-specification file')
 
 # sanity check a couple of options


### PR DESCRIPTION
This feature had already been implemented but didn't seem to be working. Basically, add a check to check one more level down in the array and we're good.

args.ini_files is a double array that looks like this:
`[["file1.ini", "file2.ini", "file3.ini", ...]]`

So check on args.ini_files needs to check args.ini_files[0]