### PR TITLE
Fix Python Client submission to AWS

### DIFF
--- a/pyenv.txt
+++ b/pyenv.txt
@@ -13,3 +13,4 @@ wheel==0.26.0
 Yapsy==1.11.223
 junit_xml==1.6
 future
+configparser

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -21,6 +21,9 @@ from requests.auth import HTTPBasicAuth
 
 from ReporterMTTStage import *
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 ## @addtogroup Stages
 # @{
 # @addtogroup Reporter

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -643,7 +644,7 @@ class IUDatabase(ReporterMTTStage):
 
         try:
             data['configure_arguments'] = logger.getLog(lg['middleware'])['configure_options']
-        except KeyError:
+        except (KeyError, TypeError):
             data['configure_arguments'] = None
 
         # For now just mark the time when submitted

--- a/server/php/cherrypy/src/mtt_server_requirements.txt
+++ b/server/php/cherrypy/src/mtt_server_requirements.txt
@@ -1,4 +1,6 @@
-CherryPy>=8.1.0
+# CherryPy at 9.0.0 is broken for our setup
+# - force the last known working version
+CherryPy==8.9.0
 requests>=2.11.1
 configobj>=5.0.6
 six>=1.10.0

--- a/server/php/cherrypy/src/webapp/dispatchers.py
+++ b/server/php/cherrypy/src/webapp/dispatchers.py
@@ -255,6 +255,20 @@ class Submit(_ServerResourceBase):
         return None
 
     #
+    # GET / : Server status
+    #
+    @cherrypy.tools.json_out()
+    def GET(self, **kwargs):
+        prefix = 'Root [GET /submit/]'
+        self.logger.debug(prefix)
+
+        rtn = {}
+        rtn['status'] = 0
+        rtn['status_message'] = 'Success (submit)'
+
+        return rtn
+
+    #
     # POST /submit/
     #
     @cherrypy.tools.json_out()


### PR DESCRIPTION
 * Fixes Issue #562
 * Working version of CherryPy is 8.9.0. Need to further investigate why later versions don't work with our configuration
 * Add `configparser` to the python client required environment
 * Ignore the `InsecureRequestWarning` to work around annoying warning message about the cert on the mtt server at AWS.