### PR TITLE
Added more verbose logging with timestamps

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -77,11 +77,11 @@ execGroup.add_argument("--ignore-loadpath-errors", action="store_true", dest="ig
 execGroup.add_argument("--scratch-dir", dest="scratchdir", default="./mttscratch",
                      help="Specify the DIRECTORY under which scratch files are to be stored", metavar="DIRECTORY")
 execGroup.add_argument("--print-section-time", dest="sectime",
-                      action="store_true", default=False,
-                      help="Display the amount of time taken in each section")
+                      action="store_true", default=True,
+                      help="Display section timestamps and execution time")
 execGroup.add_argument("--print-cmd-time", dest="cmdtime",
                      action="store_true", default=False,
-                     help="Display the amount of time taken by each command")
+                     help="Display stdout/stderr timestamps and cmd execution time")
 execGroup.add_argument("--timestamp", dest="time",
                      action="store_true", default=False,
                      help="Alias for --print-section-time --print-cmd-time")
@@ -114,6 +114,9 @@ debugGroup.add_argument("-d", "--debug", dest="debug",
 debugGroup.add_argument("--verbose",
                       action="store_true", dest="verbose", default=False,
                       help="Output some status/verbose messages while processing")
+debugGroup.add_argument("--extraverbose",
+                      action="store_true", dest="extraverbose", default=False,
+                      help="Output timestamps with every verbose message")
 debugGroup.add_argument("--dryrun",
                       action="store_true", dest="dryrun", default=False,
                       help="Show commands, but do not execute them")

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -229,7 +229,9 @@ class SequentialEx(ExecutorMTTTool):
                         continue
 
                 # execute the provided test description and capture the result
+                testDef.logger.stage_start_print(title, plugin.print_name())
                 plugin.execute(stageLog, keyvals, testDef)
+                testDef.logger.stage_end_print(title, plugin.print_name())
                 testDef.logger.logResults(title, stageLog)
                 if testDef.options['stop_on_fail'] is not False and stageLog['status'] != 0:
                     print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))

--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -26,6 +26,10 @@ class Logger(BaseMTTUtility):
         self.options = {}
         self.printout = False
         self.timestamp = False
+        self.cmdtimestamp = False
+        self.sectimestamp = False
+        self.timestampeverything = False
+        self.stage_start = {}
 
     def print_name(self):
         return "Logger"
@@ -52,6 +56,15 @@ class Logger(BaseMTTUtility):
         except KeyError:
             pass
         try:
+            if testDef.options['extraverbose']:
+                self.printout = True
+                self.timestamp = True
+                self.sectimestamp = True
+                self.cmdtimestamp = True
+                self.timestampeverything = True
+        except KeyError:
+            pass
+        try:
             if testDef.options['debug']:
                 self.printout = True
         except KeyError:
@@ -65,23 +78,40 @@ class Logger(BaseMTTUtility):
         try:
             if testDef.options['sectime']:
                 self.timestamp = True
+                self.sectimestamp = True
         except KeyError:
             pass
         try:
             if testDef.options['cmdtime']:
                 self.timestamp = True
+                self.cmdtimestamp = True
         except KeyError:
             pass
         try:
             if testDef.options['time']:
                 self.timestamp = True
+                self.cmdtimestamp = True
+                self.sectimestamp = True
         except KeyError:
             pass
         return
 
-    def verbose_print(self, str):
+    def stage_start_print(self, stagename, pluginname):
         if self.printout:
-            print(str, file=self.fh)
+            self.stage_start[stagename] = datetime.datetime.now()
+            print("%sStart executing [%s] plugin=%s" % ("%s "%self.stage_start[stagename] if self.sectimestamp else "",
+                                                            stagename, pluginname), file=self.fh)
+
+    def stage_end_print(self, stagename, pluginname):
+        if self.printout:
+            stage_end = datetime.datetime.now()
+            print("%sDone executing [%s] plugin=%s elapsed=%s" % ("%s "%stage_end if self.sectimestamp else "",
+                                                           stagename, pluginname, stage_end-self.stage_start[stagename]), file=self.fh)
+
+    def verbose_print(self, string, timestamp=None):
+        if self.printout:
+            print("%s%s" % ("%s "%(datetime.datetime.now() if timestamp is None else timestamp) \
+                            if (self.timestampeverything or timestamp) else "", string), file=self.fh)
         return
 
     def timestamp(self):


### PR DESCRIPTION
--extraverbose option added to pyclient which adds timestamps EVERYWHERE

made use of cmdtime and sectime switches (which were there but not implemented)
  - cmdtime switch enables timestamps for command execution
  - sectime switch enables timestamps for section enter/exit logging