### PR TITLE
Simpler time tracking, and JunitXML time report

### DIFF
--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -80,6 +80,10 @@ class JunitXML(ReporterMTTStage):
                 stderr = lg['stderr']
             except KeyError:
                 stderr = None
+            try:
+                time = lg['time']
+            except KeyError:
+                time = 0
             tc = TestCase(lg['section'], classname, time, stdout, stderr)
             try:
                 if 0 != lg['status']:

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -231,7 +231,7 @@ class SequentialEx(ExecutorMTTTool):
                 # execute the provided test description and capture the result
                 testDef.logger.stage_start_print(title, plugin.print_name())
                 plugin.execute(stageLog, keyvals, testDef)
-                testDef.logger.stage_end_print(title, plugin.print_name())
+                testDef.logger.stage_end_print(title, plugin.print_name(), stageLog)
                 testDef.logger.logResults(title, stageLog)
                 if testDef.options['stop_on_fail'] is not False and stageLog['status'] != 0:
                     print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))

--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -97,16 +97,17 @@ class Logger(BaseMTTUtility):
         return
 
     def stage_start_print(self, stagename, pluginname):
+        self.stage_start[stagename] = datetime.datetime.now()
         if self.printout:
-            self.stage_start[stagename] = datetime.datetime.now()
             print("%sStart executing [%s] plugin=%s" % ("%s "%self.stage_start[stagename] if self.sectimestamp else "",
                                                             stagename, pluginname), file=self.fh)
 
-    def stage_end_print(self, stagename, pluginname):
+    def stage_end_print(self, stagename, pluginname, log):
+        stage_end = datetime.datetime.now()
         if self.printout:
-            stage_end = datetime.datetime.now()
             print("%sDone executing [%s] plugin=%s elapsed=%s" % ("%s "%stage_end if self.sectimestamp else "",
                                                            stagename, pluginname, stage_end-self.stage_start[stagename]), file=self.fh)
+        log['time'] = (stage_end-self.stage_start[stagename]).total_seconds()
 
     def verbose_print(self, string, timestamp=None):
         if self.printout:


### PR DESCRIPTION
Rather than adding up all time executions in ExecuteCmd plugin,
this implements a better approach where sequential.py tracks
time execution outside of the plugin, and appends it to the log.

JunitXML plugin is also modified to grab the time info from the log
and report it.