### PR TITLE
Fix syntax error in IPMITool.py

### DIFF
--- a/pylib/Tools/CNC/IPMITool.py
+++ b/pylib/Tools/CNC/IPMITool.py
@@ -254,9 +254,9 @@ class IPMITool(CNCMTTTool):
         # the node, then we need to double it so we can execute the loop of
         # "ping" commands to detect node restart
         if reset:
-            ipmiQueue = Queue.Queue(2 * len(controllers))
+            ipmiQueue = Queue(2 * len(controllers))
         else:
-            ipmiQueue = Queue.Queue(len(controllers))
+            ipmiQueue = Queue(len(controllers))
 
         # Fill the queue
         self.lock.acquire()


### PR DESCRIPTION
ipmiQueue = Queue.Queue(2 * len(controllers))
    creates a syntax error

ipmiQueue = Queue(2 * len(controllers))
    does not create a syntax error

I changed the code to not create the syntax error