### PR TITLE
Removed unused options from all plugins

### DIFF
--- a/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
+++ b/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
@@ -17,12 +17,9 @@ from MTTDefaultsMTTStage import *
 # @{
 # @addtogroup MTTDefaults
 # @section DefaultMTTDefaults
-# @param force                 Honestly don't remember
 # @param trial                 Use when testing your MTT client setup; results that are generated and submitted to the database are marked as \"trials\" and are not included in normal reporting.
 # @param scratch               Specify the DIRECTORY under which scratch files are to be stored
-# @param logfile               Log all output to FILE (defaults to stdout)
 # @param description           Provide a brief title/description to be included in the log for this test
-# @param submit_group_results  Report results from each test section as it is completed
 # @param platform              Name of the system under test
 # @param organization          Name of the organization running the test
 # @param merge_stdout_stderr   Merge stdout and stderr into one output stream
@@ -37,12 +34,9 @@ class DefaultMTTDefaults(MTTDefaultsMTTStage):
         # initialise parent class
         MTTDefaultsMTTStage.__init__(self)
         self.options = {}
-        self.options['force'] = (False, "Honestly don't remember")
         self.options['trial'] = (False, "Use when testing your MTT client setup; results that are generated and submitted to the database are marked as \"trials\" and are not included in normal reporting.")
         self.options['scratch'] = ("./mttscratch", "Specify the DIRECTORY under which scratch files are to be stored")
-        self.options['logfile'] = (None, "Log all output to FILE (defaults to stdout)")
         self.options['description'] = (None, "Provide a brief title/description to be included in the log for this test")
-        self.options['submit_group_results'] = (True, "Report results from each test section as it is completed")
         self.options['platform'] = (None, "Name of the system under test")
         self.options['organization'] = (None, "Name of the organization running the test")
         self.options['merge_stdout_stderr'] = (False, "Merge stdout and stderr into one output stream")

--- a/pylib/Stages/TestBuild/DefaultTestBuild.py
+++ b/pylib/Stages/TestBuild/DefaultTestBuild.py
@@ -24,7 +24,6 @@ from TestBuildMTTStage import *
 # @param autogen_cmd               Command to be executed to setup the configure script, usually called autogen.sh or autogen.pl
 # @param configure_options         Options to be passed to configure. Note that the prefix will be automatically set and need not be provided here
 # @param make_options              Options to be passed to the make command
-# @param save_stdout_on_success    Save stdout even if build succeeds
 # @}
 class DefaultTestBuild(TestBuildMTTStage):
 
@@ -40,7 +39,6 @@ class DefaultTestBuild(TestBuildMTTStage):
         self.options['autogen_cmd'] = (None, "Command to be executed to setup the configure script, usually called autogen.sh or autogen.pl")
         self.options['configure_options'] = (None, "Options to be passed to configure. Note that the prefix will be automatically set and need not be provided here")
         self.options['make_options'] = (None, "Options to be passed to the make command")
-        self.options['save_stdout_on_success'] = (False, "Save stdout even if build succeeds")
 
     def activate(self):
         # get the automatic procedure from IPlugin

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -29,7 +29,6 @@ from BuildMTTTool import *
 # @param merge_stdout_stderr       Merge stdout and stderr into one output stream
 # @param stdout_save_lines         Number of lines of stdout to save
 # @param stderr_save_lines         Number of lines of stderr to save
-# @param save_stdout_on_success    Save stdout even if build succeeds
 # @param modules                   Modules to load
 # @param modules_unload            Modules to unload
 # @}
@@ -47,7 +46,6 @@ class Autotools(BuildMTTTool):
         self.options['merge_stdout_stderr'] = (False, "Merge stdout and stderr into one output stream")
         self.options['stdout_save_lines'] = (-1, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
-        self.options['save_stdout_on_success'] = (False, "Save stdout even if build succeeds")
         self.options['modules'] = (None, "Modules to load")
         self.options['modules_unload'] = (None, "Modules to unload")
         self.exclude = set(string.punctuation)

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -24,7 +24,6 @@ from BuildMTTTool import *
 # @param merge_stdout_stderr       Merge stdout and stderr into one output stream
 # @param stdout_save_lines         Number of lines of stdout to save
 # @param stderr_save_lines         Number of lines of stderr to save
-# @param save_stdout_on_success    Save stdout even if build succeeds
 # @param modules                   Modules to load
 # @param modules_unload            Modules to unload
 # @param fail_test                 Specifies whether this test is expected to fail (value=None means test is expected to succeed)
@@ -44,7 +43,6 @@ class Shell(BuildMTTTool):
         self.options['merge_stdout_stderr'] = (False, "Merge stdout and stderr into one output stream")
         self.options['stdout_save_lines'] = (-1, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
-        self.options['save_stdout_on_success'] = (False, "Save stdout even if build succeeds")
         self.options['modules'] = (None, "Modules to load")
         self.options['modules_unload'] = (None, "Modules to unload")
         self.options['fail_test'] = (None, "Specifies whether this test is expected to fail (value=None means test is expected to succeed)")

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -20,9 +20,6 @@ import shlex
 # @param hostfile                  The hostfile for OpenMPI to use
 # @param command                   Command for executing the application
 # @param np                        Number of processes to run
-# @param save_stdout_on_pass       Whether or not to save stdout on passed tests
-# @param report_after_n_results    Number of tests to run before updating the reporter
-# @param timeout                   Maximum execution time - terminate a test if it exceeds this time
 # @param options                   Comma-delimited sets of command line options that shall be used on each test
 # @param skipped                   Exit status of a test that declares it was skipped
 # @param merge_stdout_stderr       Merge stdout and stderr into one output stream
@@ -49,9 +46,6 @@ class ALPS(LauncherMTTTool):
         self.options['hostfile'] = (None, "The hostfile for ALPS to use")
         self.options['command'] = ("aprun", "Command for executing the application")
         self.options['np'] = (None, "Number of processes to run")
-        self.options['save_stdout_on_pass'] = (False, "Whether or not to save stdout on passed tests")
-        self.options['report_after_n_results'] = (None, "Number of tests to run before updating the reporter")
-        self.options['timeout'] = (None, "Maximum execution time - terminate a test if it exceeds this time")
         self.options['options'] = (None, "Comma-delimited sets of command line options that shall be used on each test")
         self.options['skipped'] = ("77", "Exit status of a test that declares it was skipped")
         self.options['merge_stdout_stderr'] = (False, "Merge stdout and stderr into one output stream")

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -23,8 +23,6 @@ import shlex
 # @param command                   Command for executing the application
 # @param np                        Number of processes to run
 # @param ppn                       Number of processes per node to run
-# @param save_stdout_on_pass       Whether or not to save stdout on passed tests
-# @param report_after_n_results    Number of tests to run before updating the reporter
 # @param timeout                   Maximum execution time - terminate a test if it exceeds this time
 # @param options                   Comma-delimited sets of command line options that shall be used on each test
 # @param skipped                   Exit status of a test that declares it was skipped
@@ -51,8 +49,6 @@ class OpenMPI(LauncherMTTTool):
         self.options['command'] = ("mpirun", "Command for executing the application")
         self.options['np'] = (None, "Number of processes to run")
         self.options['ppn'] = (None, "Number of processes per node to run")
-        self.options['save_stdout_on_pass'] = (False, "Whether or not to save stdout on passed tests")
-        self.options['report_after_n_results'] = (None, "Number of tests to run before updating the reporter")
         self.options['timeout'] = (None, "Maximum execution time - terminate a test if it exceeds this time")
         self.options['options'] = (None, "Comma-delimited sets of command line options that shall be used on each test")
         self.options['skipped'] = ("77", "Exit status of a test that declares it was skipped")

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -20,8 +20,6 @@ import shlex
 # @param hostfile                  The hostfile for OpenMPI to use
 # @param command                   Command for executing the application
 # @param np                        Number of processes to run
-# @param save_stdout_on_pass       Whether or not to save stdout on passed tests
-# @param report_after_n_results    Number of tests to run before updating the reporter
 # @param timeout                   Maximum execution time - terminate a test if it exceeds this time
 # @param options                   Comma-delimited sets of command line options that shall be used on each test
 # @param skipped                   Exit status of a test that declares it was skipped
@@ -50,8 +48,6 @@ class SLURM(LauncherMTTTool):
         self.options['hostfile'] = (None, "The hostfile for SLURM to use")
         self.options['command'] = ("srun", "Command for executing the application")
         self.options['np'] = (None, "Number of processes to run")
-        self.options['save_stdout_on_pass'] = (False, "Whether or not to save stdout on passed tests")
-        self.options['report_after_n_results'] = (None, "Number of tests to run before updating the reporter")
         self.options['timeout'] = (None, "Maximum execution time - terminate a test if it exceeds this time")
         self.options['options'] = (None, "Comma-delimited sets of command line options that shall be used on each test")
         self.options['skipped'] = ("77", "Exit status of a test that declares it was skipped")

--- a/samples/python/harasser_sample/harasser.ini
+++ b/samples/python/harasser_sample/harasser.ini
@@ -3,12 +3,8 @@
 
 # Set defaults
 [MTTDefaults]
-scratch = mttscratch
-submit_group_results = 1
-logfile = mtt-logfile-mpitest.txt
 description = MPI hello world
 platform = pluto
-force = 1
 
 [MTTDefaults:Environ]
 plugin = Environ
@@ -42,7 +38,6 @@ stop_scripts = sh dummy_harass_stop.sh
 plugin = Shell
 parent = TestGet:Dummy
 command = sh dummy_exec.sh
-save_stdout_on_pass = 1
 
 #======================================================================
 # Reporter phase

--- a/samples/python/mpitest.ini
+++ b/samples/python/mpitest.ini
@@ -16,11 +16,8 @@
 
 [MTTDefaults]
 
-force = 1
 trial = 0
-scratch = mttscratch
 submit_group_results = 1
-logfile = mtt-logfile-mpitest.txt
 description = Prototype test configuration file
 platform = bend-rsh
 
@@ -81,7 +78,6 @@ subdir = intel_tests
 
 [ASIS TestBuild:IBMInstalled]
 parent = TestGet:IBM
-save_stdout_on_success = 1
 merge_stdout_stderr = 1
 stderr_save_lines = 100
 
@@ -104,11 +100,9 @@ options = ["", "--novm"]
 
 skipped = 77
 
-save_stdout_on_pass = 1
 merge_stdout_stderr = 1
 stdout_save_lines = 100
 stderr_save_lines = 100
-report_after_n_results = 100
 
 #
 #======================================================================
@@ -122,7 +116,6 @@ report_after_n_results = 100
 [TestRun:IBMInstalledOMPI]
 plugin = OpenMPI
 parent = TestBuild:IBMInstalled
-timeout = 600
 #test_dir = "collective, communicator, datatype, environment, group, info, io, onesided, pt2pt, random, topology"
 test_dir = "collective, communicator"
 max_num_tests = 10

--- a/samples/python/ompi_hello_world.ini
+++ b/samples/python/ompi_hello_world.ini
@@ -3,12 +3,8 @@
 
 # Set defaults
 [MTTDefaults]
-scratch = mttscratch
-submit_group_results = 1
-logfile = mtt-logfile-mpitest.txt
 description = MPI hello world
 platform = pluto
-force = 1
 
 # Get the system profile
 [Profile:Installed]
@@ -27,7 +23,6 @@ branch = v1.10
 [ASIS MiddlewareBuild:OMPI]
 plugin = Autotools
 parent = MiddlewareGet:OMPI
-save_stdout_on_success = 1
 
 autogen_cmd = ./autogen.pl
 configure_options = 
@@ -49,7 +44,6 @@ src = /opt/mtt/samples/python/
 [TestBuild:HelloWorld]
 parent = TestGet:HelloWorld
 plugin = Shell
-save_stdout_on_success = 1
 
 # Use our built ompi install
 middleware = MiddlewareBuild:OMPI
@@ -68,7 +62,6 @@ options = -N 4
 [TestRun:HelloWorld]
 plugin = SLURM
 parent = TestBuild:HelloWorld
-save_stdout_on_pass = 1
 test_list = mpi_hello_world
 
 #======================================================================


### PR DESCRIPTION
Several options were unimplimented in plugins, so I removed them.

We can add them again as we create functionality.

These removed options include:
 - force
 - logfile
 - submit_group_results
 - save_stdout_on_success
 - save_stdout_on_pass
 - report_after_n_results
 - timeout