### PR TITLE
php/submit: Fix leftover temp file if gzip fails

### DIFF
--- a/server/php/submit/index.php
+++ b/server/php/submit/index.php
@@ -2044,7 +2044,10 @@ function setup_post() {
         $out_to_log  = "--------------------------------------- gzip failed...\n";
         $out_to_log .= "Date: ".$date."\n";
         $out_to_log .= "gunzip failed (in gzopen). Please check tmp dir for overflow.\n";
+        $out_to_log .= "Filename: ".$filename."\n";
         error_log($out_to_log, 3, $mtt_err_log_file);
+        fclose($fp);
+        unlink($temp_filename);
         mtt_abort(400, "gunzip failed. Contact MTT Admins for help!");
         exit(1);
         #return null;


### PR DESCRIPTION
 * If gzopen fails then the temporary target file is left in the
   filesystem in the abort path.
   - This makes sure we close the handle, and unlink the temporary
     file. Additionally, it adds a diagnostic message to the log.