### PR TITLE
Build::Noop: support external test location

### DIFF
--- a/lib/MTT/Test/Build.pm
+++ b/lib/MTT/Test/Build.pm
@@ -557,6 +557,10 @@ sub _do_build {
         $report->{submit_id} = $submit_id;
         $ret->{submitl_id} = $submit_id;
 
+        if ($ret->{installdir}) {
+            $report->{installdir} = $ret->{installdir};
+        }
+
         # Submit it!
         my $serials = MTT::Reporter::Submit("Test Build", $simple_section, $report);
 

--- a/lib/MTT/Test/Build/Noop.pm
+++ b/lib/MTT/Test/Build/Noop.pm
@@ -12,13 +12,24 @@ package MTT::Test::Build::Noop;
 
 use strict;
 
+use MTT::Values;
+
 #--------------------------------------------------------------------------
 
 sub Build {
+    my ($ini, $mpi_install, $config) = @_;
+
+    # In case of tests located in different folder and no much space available
+    # on target scratch, it can be useful to point another location of prebuilt
+    # tests.
+    my $install_dir = Value($ini, $config->{full_section_name}, "installdir");
+
     my $ret;
     $ret->{test_result} = MTT::Values::PASS;
     $ret->{exit_status} = 0;
     $ret->{result_message} = "Success";
+    $ret->{installdir} = $install_dir if $install_dir;
+
     return $ret;
 } 
 

--- a/lib/MTT/Test/Run.pm
+++ b/lib/MTT/Test/Run.pm
@@ -429,7 +429,10 @@ sub _do_run {
         $ini->val($mpi_details_section, "network$suffix");
 
     # Go to the right dir
-    MTT::DoCommand::Chdir($test_build->{srcdir});
+    # 'installdir' is defined by build module, so it has higher priority
+    my $test_bin_dir = $test_build->{installdir} ? $test_build->{installdir}
+                                                 : $test_build->{srcdir};
+    MTT::DoCommand::Chdir($test_bin_dir);
 
     # Set the PATH and LD_LIBRARY_PATH
     if ($mpi_install->{bindir}) {


### PR DESCRIPTION
Original discussion: https://github.com/open-mpi/mtt/pull/601.