### PR TITLE
Added Copytree plugin switch for preserve_symlinks.

### DIFF
--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -18,13 +18,15 @@ from BaseMTTUtility import *
 ## @addtogroup Utilities
 # @{
 # @section Copytree
-# @param  src    The top directory of the tree to be copied
+# @param  src                 The top directory of the tree to be copied
+# @param  preserve_symlinks   Preserve symlinks instead of copying the contents
 # @}
 class Copytree(BaseMTTUtility):
     def __init__(self):
         BaseMTTUtility.__init__(self)
         self.options = {}
         self.options['src'] = (None, "The top directory of the tree to be copied")
+        self.options['preserve_symlinks'] = ("0", "Preserve symlinks instead of copying the contents")
 
     def print_name(self):
         return "Copytree"
@@ -72,7 +74,7 @@ class Copytree(BaseMTTUtility):
             for srcpath in cmds['src'].split(','):
                 srcpath = srcpath.strip()
                 reload(distutils.dir_util)
-                distutils.dir_util.copy_tree(srcpath, dst)
+                distutils.dir_util.copy_tree(srcpath, dst, preserve_symlinks=int(cmds['preserve_symlinks']))
             log['status'] = 0
         except (os.error, shutil.Error, \
                 distutils.errors.DistutilsFileError) as e:


### PR DESCRIPTION
Default value is to not preserve symlinks and copy the contents instead.

Signed-off-by: Noah van Dresser <daniel.n.van.dresser@intel.com>