### PR TITLE
Add interpolation for accessing log in INI files

### DIFF
--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -88,6 +88,11 @@ class SequentialEx(ExecutorMTTTool):
                     stage = stage.strip()
                 else:
                     stage = title
+
+                testDef.configTest()
+                testDef.logger.verbose_print("OPTIONS FOR SECTION: %s" % title)
+                testDef.logger.verbose_print(testDef.config.items(title))
+
                 # setup the log
                 stageLog = {'section':title}
                 # get the key-value tuples output by the configuration parser


### PR DESCRIPTION
Log results from stages can now be accessed within INI files from other stages

This interpolation is similar syntax to accessing environment variables

The syntax for accessing the log in INI files is like so:
(for results from stage TestBuild:Buildingstuff)
${LOG:TestBuild_Buildingstuff.stdout}
${LOG:TestBuild_Buildingstuff.options.platform}

":" is replaced with "_" for the stage names in the interpolation syntax