### PR TITLE
pyclient: squash some Watchdog problems

### DIFF
--- a/pylib/Utilities/Watchdog.py
+++ b/pylib/Utilities/Watchdog.py
@@ -3,6 +3,8 @@ from builtins import str
 #!/usr/bin/env python
 #
 # Copyright (c) 2015-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2018      Los Alamos National Security, LLC. 
+#                         All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,9 +23,10 @@ from BaseMTTUtility import *
 # @param  timeout  Time in seconds before generating exception
 # @}
 class Watchdog(BaseMTTUtility):
-    def __init__(self, timeout):
+    def __init__(self, timeout=360):
         BaseMTTUtility.__init__(self)
         self.timeout = timeout
+        self.options = {}
         self.options['time'] = (None, "Time in seconds before generating exception")
         self.timer = Timer(self.timeout, self.defaultHandler)
 


### PR DESCRIPTION
set timeout default to 6 minutes.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>