### PR TITLE
"deactivate" ran for plugins when interrupted

### DIFF
--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -343,9 +343,9 @@ class Shell(BuildMTTTool):
         cfgargs = shlex.split(cmds['command'])
 
         if 'TestRun' in log['section'].split(":")[0]:
-            harass_exec_ids = testDef.harasser.start(log, testDef)
+            harass_exec_ids = testDef.harasser.start(testDef)
 
-            harass_check = testDef.harasser.check(harass_exec_ids, log, testDef)
+            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
             if harass_check is not None:
                 log['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
                                 + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
@@ -357,7 +357,7 @@ class Shell(BuildMTTTool):
         status, stdout, stderr, time = testDef.execmd.execute(cmds, cfgargs, testDef)
 
         if 'TestRun' in log['section'].split(":")[0]:
-            testDef.harasser.stop(harass_exec_ids, log, testDef)
+            testDef.harasser.stop(harass_exec_ids, testDef)
 
         # Deallocate cluster
         if False == self.deallocate(log, cmds, testDef):

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -64,103 +64,139 @@ class SequentialEx(ExecutorMTTTool):
     def execute(self, testDef):
         testDef.logger.verbose_print("ExecuteSequential")
         status = 0
+        only_reporter = False
+        stageOrder = testDef.loader.stageOrder
         for step in testDef.loader.stageOrder:
             for title in testDef.config.sections():
-                if (":" in title and step not in title.split(":")[0]) or \
-                   (":" not in title and step not in title):
+                if only_reporter and step != "Reporter":
                     continue
-                # see if this is a step we are to execute
-                if title not in testDef.actives:
-                    continue
-                testDef.logger.verbose_print(title)
-                # if they provided the STOP section, that means we
-                # are to immediately stop processing the test definition
-                # file and return
-                if "STOP" in title:
-                    return
-                # if they included the "SKIP" qualifier, then we skip
-                # this section
-                if "SKIP" in title:
-                    continue
-                # extract the stage and stage name from the title
-                if ":" in title:
-                    stage,name = title.split(':')
-                    stage = stage.strip()
-                else:
-                    stage = title
-
-                testDef.configTest()
-                testDef.logger.verbose_print("OPTIONS FOR SECTION: %s" % title)
-                testDef.logger.verbose_print(testDef.config.items(title))
-
-                # setup the log
-                stageLog = {'section':title}
-                # get the key-value tuples output by the configuration parser
-                stageLog["parameters"] = testDef.config.items(title)
-                # convert the list of key-value tuples provided in this stage
-                # by the user to a dictionary for easier parsing.
-                # Yes, we could do this automatically, but we instead do it
-                # manually so we can strip all the keys and values for easier
-                # parsing later
-                keyvals = {'section':title.strip()}
-                for kv in testDef.config.items(title):
-                    keyvals[kv[0].strip()] = kv[1].strip()
-                # if they included the "ASIS" qualifier, remove it
-                # from the stage name
-                if "ASIS" in stage:
-                    # find the first non-space character
-                    i = 4
-                    while stage[i].isspace():
-                        i = i + 1
-                    stage = stage[i:]
-                    stageLog['section'] = title[i:].strip()
-                    keyvals['section'] = title[i:].strip()
-                    keyvals['asis'] = True
-                # if this stage has a parent, get the log for that stage
-                # and check its status - if it didn't succeed, then we shall
-                # log this stage as also having failed and skip it
                 try:
-                    parent = keyvals['parent']
-                    if parent is not None:
-                        # get the log entry as it contains the status
-                        bldlog = testDef.logger.getLog(parent)
-                        if bldlog is None:
-                            # couldn't find the parent's log - cannot continue
-                            stageLog['status'] = 1
-                            stageLog['stderr'] = "Prior dependent step did not record a log"
-                            testDef.logger.logResults(title, stageLog)
-                            continue
-                        try:
-                            if bldlog['status'] != 0:
-                                # the parent step failed, and so we
-                                # cannot proceed here either
-                                stageLog['status'] = bldlog['status']
-                                stageLog['stderr'] = "Prior dependent step failed - cannot proceed"
+                    if (":" in title and step not in title.split(":")[0]) or \
+                       (":" not in title and step not in title):
+                        continue
+                    # see if this is a step we are to execute
+                    if title not in testDef.actives:
+                        continue
+                    testDef.logger.verbose_print(title)
+                    # if they provided the STOP section, that means we
+                    # are to immediately stop processing the test definition
+                    # file and return
+                    if "STOP" in title:
+                        return
+                    # if they included the "SKIP" qualifier, then we skip
+                    # this section
+                    if "SKIP" in title:
+                        continue
+                    # extract the stage and stage name from the title
+                    if ":" in title:
+                        stage,name = title.split(':')
+                        stage = stage.strip()
+                    else:
+                        stage = title
+
+                    testDef.configTest()
+                    testDef.logger.verbose_print("OPTIONS FOR SECTION: %s" % title)
+                    testDef.logger.verbose_print(testDef.config.items(title))
+
+                    # setup the log
+                    stageLog = {'section':title}
+                    # get the key-value tuples output by the configuration parser
+                    stageLog["parameters"] = testDef.config.items(title)
+                    # convert the list of key-value tuples provided in this stage
+                    # by the user to a dictionary for easier parsing.
+                    # Yes, we could do this automatically, but we instead do it
+                    # manually so we can strip all the keys and values for easier
+                    # parsing later
+                    keyvals = {'section':title.strip()}
+                    for kv in testDef.config.items(title):
+                        keyvals[kv[0].strip()] = kv[1].strip()
+                    # if they included the "ASIS" qualifier, remove it
+                    # from the stage name
+                    if "ASIS" in stage:
+                        # find the first non-space character
+                        i = 4
+                        while stage[i].isspace():
+                            i = i + 1
+                        stage = stage[i:]
+                        stageLog['section'] = title[i:].strip()
+                        keyvals['section'] = title[i:].strip()
+                        keyvals['asis'] = True
+                    # if this stage has a parent, get the log for that stage
+                    # and check its status - if it didn't succeed, then we shall
+                    # log this stage as also having failed and skip it
+                    try:
+                        parent = keyvals['parent']
+                        if parent is not None:
+                            # get the log entry as it contains the status
+                            bldlog = testDef.logger.getLog(parent)
+                            if bldlog is None:
+                                # couldn't find the parent's log - cannot continue
+                                stageLog['status'] = 1
+                                stageLog['stderr'] = "Prior dependent step did not record a log"
                                 testDef.logger.logResults(title, stageLog)
                                 continue
-                        except KeyError:
-                            # if it didn't report a status, we shouldn't rely on it
-                            stageLog['status'] = 1
-                            stageLog['stderr'] = "Prior dependent step failed to provide a status"
-                            testDef.logger.logResults(title, stageLog)
-                            continue
-                except KeyError:
-                    pass
-                # extract the name of the plugin to use
-                plugin = None
-                try:
-                    module = keyvals['plugin']
-                    # see if this plugin exists
+                            try:
+                                if bldlog['status'] != 0:
+                                    # the parent step failed, and so we
+                                    # cannot proceed here either
+                                    stageLog['status'] = bldlog['status']
+                                    stageLog['stderr'] = "Prior dependent step failed - cannot proceed"
+                                    testDef.logger.logResults(title, stageLog)
+                                    continue
+                            except KeyError:
+                                # if it didn't report a status, we shouldn't rely on it
+                                stageLog['status'] = 1
+                                stageLog['stderr'] = "Prior dependent step failed to provide a status"
+                                testDef.logger.logResults(title, stageLog)
+                                continue
+                    except KeyError:
+                        pass
+                    # extract the name of the plugin to use
+                    plugin = None
                     try:
-                        for pluginInfo in testDef.stages.getPluginsOfCategory(stage):
-                            if module == pluginInfo.plugin_object.print_name():
-                                plugin = pluginInfo.plugin_object
-                                break
-                        if plugin is None:
-                            # this plugin doesn't exist, or it may not be a stage as
-                            # sometimes a stage consists of executing a tool or utility.
-                            # so let's check the tools too, noting that those
-                            # are not stage-specific.
+                        module = keyvals['plugin']
+                        # see if this plugin exists
+                        try:
+                            for pluginInfo in testDef.stages.getPluginsOfCategory(stage):
+                                if module == pluginInfo.plugin_object.print_name():
+                                    plugin = pluginInfo.plugin_object
+                                    break
+                            if plugin is None:
+                                # this plugin doesn't exist, or it may not be a stage as
+                                # sometimes a stage consists of executing a tool or utility.
+                                # so let's check the tools too, noting that those
+                                # are not stage-specific.
+                                availTools = list(testDef.loader.tools.keys())
+                                for tool in availTools:
+                                    for pluginInfo in testDef.tools.getPluginsOfCategory(tool):
+                                        if module == pluginInfo.plugin_object.print_name():
+                                            plugin = pluginInfo.plugin_object
+                                            break
+                                    if plugin is not None:
+                                        break;
+                                if plugin is None:
+                                    # Check the utilities
+                                    availUtils = list(testDef.loader.utilities.keys())
+                                    for util in availUtils:
+                                        for pluginInfo in testDef.utilities.getPluginsOfCategory(util):
+                                            if module == pluginInfo.plugin_object.print_name():
+                                                plugin = pluginInfo.plugin_object
+                                                break
+                                        if plugin is not None:
+                                            break;
+                                if plugin is None:
+                                    stageLog['status'] = 1
+                                    stageLog['stderr'] = "Specified plugin",module,"does not exist in stage",stage,"or in the available tools and utilities"
+                                    testDef.logger.logResults(title, stageLog)
+                                    continue
+                                else:
+                                    # activate the specified plugin
+                                    testDef.tools.activatePluginByName(module, tool)
+                            else:
+                                # activate the specified plugin
+                                testDef.stages.activatePluginByName(module, stage)
+                        except KeyError:
+                            # If this stage has no plugins then check the tools and the utilities
                             availTools = list(testDef.loader.tools.keys())
                             for tool in availTools:
                                 for pluginInfo in testDef.tools.getPluginsOfCategory(tool):
@@ -187,66 +223,48 @@ class SequentialEx(ExecutorMTTTool):
                             else:
                                 # activate the specified plugin
                                 testDef.tools.activatePluginByName(module, tool)
-                        else:
-                            # activate the specified plugin
-                            testDef.stages.activatePluginByName(module, stage)
                     except KeyError:
-                        # If this stage has no plugins then check the tools and the utilities
-                        availTools = list(testDef.loader.tools.keys())
-                        for tool in availTools:
-                            for pluginInfo in testDef.tools.getPluginsOfCategory(tool):
-                                if module == pluginInfo.plugin_object.print_name():
-                                    plugin = pluginInfo.plugin_object
-                                    break
-                            if plugin is not None:
-                                break;
+                        # if they didn't specify a plugin, use the default if one
+                        # is available and so designated
+                        default = "Default{0}".format(stage)
+                        for pluginInfo in testDef.stages.getPluginsOfCategory(stage):
+                            if default == pluginInfo.plugin_object.print_name():
+                                plugin = pluginInfo.plugin_object
+                                break
                         if plugin is None:
-                            # Check the utilities
-                            availUtils = list(testDef.loader.utilities.keys())
-                            for util in availUtils:
-                                for pluginInfo in testDef.utilities.getPluginsOfCategory(util):
-                                    if module == pluginInfo.plugin_object.print_name():
-                                        plugin = pluginInfo.plugin_object
-                                        break
-                                if plugin is not None:
-                                    break;
-                        if plugin is None:
+                            # we really have no way of executing this
                             stageLog['status'] = 1
-                            stageLog['stderr'] = "Specified plugin",module,"does not exist in stage",stage,"or in the available tools and utilities"
+                            stageLog['stderr'] = "Plugin for stage",stage,"was not specified, and no default is available"
                             testDef.logger.logResults(title, stageLog)
                             continue
-                        else:
-                            # activate the specified plugin
-                            testDef.tools.activatePluginByName(module, tool)
-                except KeyError:
-                    # if they didn't specify a plugin, use the default if one
-                    # is available and so designated
-                    default = "Default{0}".format(stage)
-                    for pluginInfo in testDef.stages.getPluginsOfCategory(stage):
-                        if default == pluginInfo.plugin_object.print_name():
-                            plugin = pluginInfo.plugin_object
-                            break
-                    if plugin is None:
-                        # we really have no way of executing this
-                        stageLog['status'] = 1
-                        stageLog['stderr'] = "Plugin for stage",stage,"was not specified, and no default is available"
-                        testDef.logger.logResults(title, stageLog)
-                        continue
 
-                # execute the provided test description and capture the result
-                testDef.logger.stage_start_print(title, plugin.print_name())
-                plugin.execute(stageLog, keyvals, testDef)
-                testDef.logger.stage_end_print(title, plugin.print_name(), stageLog)
-                testDef.logger.logResults(title, stageLog)
-                if testDef.options['stop_on_fail'] is not False and stageLog['status'] != 0:
-                    print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))
-                    try:
-                        print("Section " + stageLog['section'] + ": Stderr " + str(stageLog['stderr']))
-                    except KeyError:
-                        pass
-                    sys.exit(1)
+                    # execute the provided test description and capture the result
+                    testDef.logger.stage_start_print(title, plugin.print_name())
+                    plugin.execute(stageLog, keyvals, testDef)
+                    testDef.logger.stage_end_print(title, plugin.print_name(), stageLog)
+                    testDef.logger.logResults(title, stageLog)
+                    if testDef.options['stop_on_fail'] is not False and stageLog['status'] != 0:
+                        print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))
+                        try:
+                            print("Section " + stageLog['section'] + ": Stderr " + str(stageLog['stderr']))
+                        except KeyError:
+                            pass
+                        sys.exit(1)
          
-                # Set flag if any stage failed so that a return code can be passed back up
-                if stageLog['status'] != 0:
+                    # Set flag if any stage failed so that a return code can be passed back up
+                    if stageLog['status'] != 0:
+                        status = 1
+                except BaseException as e:
+                    for p in testDef.stages.getAllPlugins() \
+                           + testDef.tools.getAllPlugins() \
+                           + testDef.utilities.getAllPlugins():
+                        if not p._getIsActivated():
+                            continue
+                        p.plugin_object.deactivate()
+                    stageLog['status'] = 1
+                    stageLog['stderr'] = "Exception was raised: %s %s" % (type(e), str(e))
+                    testDef.logger.logResults(title, stageLog)
                     status = 1
+                    only_reporter = True
+                    continue
         return status

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -420,9 +420,9 @@ class ALPS(LauncherMTTTool):
             cmdargs.append(test)
             testLog['cmd'] = " ".join(cmdargs)
 
-            harass_exec_ids = testDef.harasser.start(testLog, testDef)
+            harass_exec_ids = testDef.harasser.start(testDef)
 
-            harass_check = testDef.harasser.check(harass_exec_ids, testLog, testDef)
+            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
             if harass_check is not None:
                 testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
                                 + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
@@ -431,12 +431,12 @@ class ALPS(LauncherMTTTool):
                 finalStatus = 1
                 finalError = testLog['stderr']
                 numFail = numFail + 1
-                testDEef.harasser.stop(harass_exec_ids, testLog, testDef)
+                testDef.harasser.stop(harass_exec_ids, testDef)
                 continue
 
             status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
 
-            testDef.harasser.stop(harass_exec_ids, testLog, testDef)
+            testDef.harasser.stop(harass_exec_ids, testDef)
 
             if 0 != status and skipStatus != status and 0 == finalStatus:
                 if expected_returncodes[test] == 0:

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -355,9 +355,9 @@ class OpenMPI(LauncherMTTTool):
             cmdargs.append(test)
             testLog['cmd'] = " ".join(cmdargs)
 
-            harass_exec_ids = testDef.harasser.start(testLog, testDef)
+            harass_exec_ids = testDef.harasser.start(testDef)
 
-            harass_check = testDef.harasser.check(harass_exec_ids, testLog, testDef)
+            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
             if harass_check is not None:
                 testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
                                 + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
@@ -366,12 +366,12 @@ class OpenMPI(LauncherMTTTool):
                 finalStatus = 1
                 finalError = testLog['stderr']
                 numFail = numFail + 1
-                testDef.harasser.stop(harass_exec_ids, testLog, testDef)
+                testDef.harasser.stop(harass_exec_ids, testDef)
                 continue
 
             status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
 
-            testDef.harasser.stop(harass_exec_ids, testLog, testDef)
+            testDef.harasser.stop(harass_exec_ids, testDef)
 
             if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
                 if expected_returncodes[test] == 0:

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -439,9 +439,9 @@ class SLURM(LauncherMTTTool):
             cmdargs.extend(shlex.split(test))
             testLog['cmd'] = " ".join(["\"%s\"" % cmdarg if " " in cmdarg else cmdarg for cmdarg in cmdargs])
 
-            harass_exec_ids = testDef.harasser.start(testLog, testDef)
+            harass_exec_ids = testDef.harasser.start(testDef)
 
-            harass_check = testDef.harasser.check(harass_exec_ids, testLog, testDef)
+            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
             if harass_check is not None:
                 testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
                                 + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
@@ -450,12 +450,12 @@ class SLURM(LauncherMTTTool):
                 finalStatus = 1
                 finalError = testLog['stderr']
                 numFail = numFail + 1
-                testDef.harasser.stop(harass_exec_ids, testLog, testDef)
+                testDef.harasser.stop(harass_exec_ids, testDef)
                 continue
 
             status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
 
-            testDef.harasser.stop(harass_exec_ids, testLog, testDef)
+            testDef.harasser.stop(harass_exec_ids, testDef)
 
             if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
                 if expected_returncodes[test] == 0:

--- a/samples/python/harasser_sample/dummy_harass_start.sh
+++ b/samples/python/harasser_sample/dummy_harass_start.sh
@@ -4,7 +4,7 @@ echo "$fname: Start time "`date`
 
 echo "$fname: pid = $$"
 
-./dummy_harass.sh &
+nohup ./dummy_harass.sh &
 pid=$!
 echo $pid > dummy_harass_pid
 echo "$fname: Started pid $pid"


### PR DESCRIPTION
When code execution is interrupted by ctrl+c or by some other means, the plugins "deactivate" function is called, which can give plugins a chance to clean up.

The cleanup is implemented for the Harasser plugin