### PR TITLE
Add --cleanup switch, cleans scratchdir on success

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -88,6 +88,9 @@ execGroup.add_argument("--timestamp", dest="time",
 execGroup.add_argument("--clean-start", dest="clean",
                      action="store_true",
                      help="Clean the scratch directory from past MTT invocations before running")
+execGroup.add_argument("-c", "--cleanup", dest="clean_after",
+                     action="store_true",
+                     help="Clean the scratch directory after a successful run")
 execGroup.add_argument("-s", "--sections", dest="section",
                      help="Execute the specified SECTION (or comma-delimited list of SECTIONs)", metavar="SECTION")
 execGroup.add_argument("--skip-sections", dest="skipsections",

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -650,6 +650,9 @@ class TestDef(object):
         # execute the provided test description
         executor = self.tools.getPluginByName("sequential", "Executor")
         status = executor.plugin_object.execute(self)
+        if status == 0 and self.options['clean_after'] and os.path.isdir(self.options['scratchdir']):
+            self.logger.verbose_print("Cleaning up scratchdir after successful run")
+            shutil.rmtree(self.options['scratchdir'])
         return status
 
     def executeCombinatorial(self):


### PR DESCRIPTION
After a successful run, scratchdir is cleaned up when '--cleanup' or '-c' is specified as a switch