### PR TITLE
Add --duration and --loopforever switches to MTT

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -109,6 +109,12 @@ execGroup.add_argument("--env-module-wrapper", dest="env_module_wrapper", defaul
 execGroup.add_argument("--stop-on-fail", dest="stop_on_fail",
                      action="store_true", default=False,
                      help="If a stage fails, exit and issue a non-zero return code")
+execGroup.add_argument("--duration",
+                     dest="duration", default=None,
+                     help="Add a maximum duration for test before interrupting.")
+execGroup.add_argument("--loopforever", dest="loopforever",
+                     action="store_true", default=False,
+                     help="Causes MTT to continue to loop forever running same set of tests. Use this in conjunction with --duration switch to loop for a specific amount of time.")
 
 debugGroup = parser.add_argument_group('debugGroup', 'Debug Options')
 debugGroup.add_argument("-d", "--debug", dest="debug",

--- a/pylib/Stages/Provisioning/WWulf3.py
+++ b/pylib/Stages/Provisioning/WWulf3.py
@@ -43,6 +43,10 @@ class WWulf3(ProvisionMTTStage):
         self.options['sudo'] = (False, "Use sudo to execute privileged commands")
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
+
+        self.allocated = False
+        self.testDef = None
+        self.cmds = None
         return
 
 
@@ -54,7 +58,8 @@ class WWulf3(ProvisionMTTStage):
 
     def deactivate(self):
         IPlugin.deactivate(self)
-
+        if self.allocated and self.testDef and self.cmds:
+            self.deallocate({}, self.cmds, self.testDef)
 
     def print_name(self):
         return "WWulf3"
@@ -85,7 +90,6 @@ class WWulf3(ProvisionMTTStage):
         if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated == True:
             deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
             status,stdout,stderr,time = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
-            self.allocated = False
             if 0 != status:
                 log['status'] = status
                 if log['stderr']:
@@ -93,6 +97,7 @@ class WWulf3(ProvisionMTTStage):
                 else:
                     log['stderr'] = stderr
                 return False
+            self.allocated = False
         return True
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -637,7 +637,8 @@ class TestDef(object):
                 self.logger.verbose_print(self.config.items(section))
         return
 
-    def executeTest(self):
+    def executeTest(self, enable_loop=True):
+
         if not self.loaded:
             print("Plugins have not been loaded - cannot execute test")
             exit(1)
@@ -655,6 +656,11 @@ class TestDef(object):
         if status == 0 and self.options['clean_after'] and os.path.isdir(self.options['scratchdir']):
             self.logger.verbose_print("Cleaning up scratchdir after successful run")
             shutil.rmtree(self.options['scratchdir'])
+
+        if enable_loop and self.options['loopforever']:
+            while True:
+                self.logger.reset()
+                self.executeTest(enable_loop=False)
         return status
 
     def executeCombinatorial(self):

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -64,6 +64,10 @@ class OpenMPI(LauncherMTTTool):
         self.options['test_list'] = (None, "List of tests to run, default is all")
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
+
+        self.allocated = False
+        self.testDef = None
+        self.cmds = None
         return
 
 
@@ -75,7 +79,10 @@ class OpenMPI(LauncherMTTTool):
 
     def deactivate(self):
         IPlugin.deactivate(self)
-
+        if self.allocated and self.testDef and self.cmds:
+            deallocate_cmdargs = shlex.split(self.cmds['deallocate_cmd'])
+            _status,_stdout,_stderr,_time = self.testDef.execmd.execute(self.cmds, deallocate_cmdargs, self.testDef)
+            self.allocated = False
 
     def print_name(self):
         return "OpenMPI"
@@ -87,6 +94,8 @@ class OpenMPI(LauncherMTTTool):
         return
 
     def execute(self, log, keyvals, testDef):
+
+        self.testDef = testDef
 
         midpath = False
 
@@ -212,6 +221,7 @@ class OpenMPI(LauncherMTTTool):
         # parse any provided options - these will override the defaults
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
+        self.cmds = cmds
         # now ready to execute the test - we are pointed at the middleware
         # and have obtained the list of any modules associated with it. We need
         # to change to the test location and begin executing, first saving
@@ -332,8 +342,9 @@ class OpenMPI(LauncherMTTTool):
                 expected_returncodes = {test:(fail_returncodes[test] if test in fail_returncodes else 0) for test in tests}
 
         # Allocate cluster
-        allocated = False
+        self.allocated = False
         if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None:
+            self.allocated = True
             allocate_cmdargs = shlex.split(cmds['allocate_cmd'])
             _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
             if 0 != _status:
@@ -341,7 +352,6 @@ class OpenMPI(LauncherMTTTool):
                 log['stderr'] = _stderr
                 os.chdir(cwd)
                 return
-            allocated = True
 
         for test in tests:
             # Skip tests that are in "skip_tests" ini input
@@ -402,7 +412,7 @@ class OpenMPI(LauncherMTTTool):
                 break
 
         # Deallocate cluster
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and allocated:
+        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated:
             deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
             _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
             if 0 != _status:
@@ -410,6 +420,7 @@ class OpenMPI(LauncherMTTTool):
                 log['stderr'] = _stderr
                 os.chdir(cwd)
                 return
+            self.allocated = False
 
         log['status'] = finalStatus
         log['stderr'] = finalError

--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -31,6 +31,10 @@ class Logger(BaseMTTUtility):
         self.timestampeverything = False
         self.stage_start = {}
 
+    def reset(self):
+        self.results = []
+        self.stage_start = {}
+
     def print_name(self):
         return "Logger"
 


### PR DESCRIPTION
With --duration switch, MTT will have a maximum duration for tests to run.
This duration applies to all tests being run by MTT, even if multiple tests
are ran at a time. (If duration ends test will interrupt and return success)

With --loopforever switch MTT will continue to run forever until interrupted.

The two switches work together to have a test keep running over and over for a specified amount of time.

Allocation and deallocation commands were fixed so that deallocation happens if
the execution was interrupted by the duration timing out (or by another interruption)