### PR TITLE
remove carriage return from latest_snapshot.txt

### DIFF
--- a/pylib/Tools/Fetch/OMPI_Snapshot.py
+++ b/pylib/Tools/Fetch/OMPI_Snapshot.py
@@ -127,7 +127,7 @@ class OMPI_Snapshot(FetchMTTTool):
             pass
 
         # build the tarball name, using a base and then full name
-        tarball_base_name = 'openmpi-' + snapshot_req.text
+        tarball_base_name = 'openmpi-' + snapshot_req.text.strip()
         tarball_name = tarball_base_name + '.tar.gz'
         download_url = url + '/' + tarball_name
 


### PR DESCRIPTION
Appearently as part of the move of the OMPI snapshot
tarballs to S3, a \n got added to the content
of latest_snapshot.txt return, borking up the
OMPI snapshot plugin's snapshot download attempts.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>