### PR TITLE
OMPI snapshot: add way to specify MPI name/version

### DIFF
--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -150,20 +150,29 @@ class Autotools(BuildMTTTool):
             log['compiler'] = compilerLog
         testDef.logger.verbose_print(log['compiler'])
 
-        # Find MPI information for IUDatabase plugin
-        plugin = None
-        availUtil = list(testDef.loader.utilities.keys())
-        for util in availUtil:
-            for pluginInfo in testDef.utilities.getPluginsOfCategory(util):
-                if "MPIVersion" == pluginInfo.plugin_object.print_name():
-                    plugin = pluginInfo.plugin_object
-                    break
-        if plugin is None:
-            log['mpi_info'] = {'name' : 'unknown', 'version' : 'unknown'}
+        # Find MPI information for IUDatabase plugin if
+        # mpi_info is not already set
+        fullLog = testDef.logger.getLog(None)
+        mpi_info_found = False
+        for lg in fullLog:
+            if 'mpi_info' in lg:
+                mpi_info_found = True
+        if mpi_info_found is False:
+            plugin = None
+            availUtil = list(testDef.loader.utilities.keys())
+            for util in availUtil:
+                for pluginInfo in testDef.utilities.getPluginsOfCategory(util):
+                    if "MPIVersion" == pluginInfo.plugin_object.print_name():
+                        plugin = pluginInfo.plugin_object
+                        break
+            if plugin is None:
+                log['mpi_info'] = {'name' : 'unknown', 'version' : 'unknown'}
+            else:
+                mpi_info = {}
+                plugin.execute(mpi_info, testDef)
+                log['mpi_info'] = mpi_info
         else:
-            mpi_info = {}
-            plugin.execute(mpi_info, testDef)
-            log['mpi_info'] = mpi_info
+            testDef.logger.verbose_print("mpi_info already in log so skipping MPIVersion")
 
         # Add configure options to log for IUDatabase plugin
         try:

--- a/pylib/Tools/Fetch/OMPI_Snapshot.py
+++ b/pylib/Tools/Fetch/OMPI_Snapshot.py
@@ -26,6 +26,7 @@ import sys
 # @section OMPI_Snapshot
 # @param url            URL to access the OMPI nightly tarball (e.g. https://www.open-mpi.org/nightly/v2.x)
 # @param version_file   optional file containing name of most recent tarball version tested
+# @param mpi_name       optional name for the OMPI snapshot tarball
 # @}
 class OMPI_Snapshot(FetchMTTTool):
 
@@ -39,6 +40,7 @@ class OMPI_Snapshot(FetchMTTTool):
         self.options = {}
         self.options['url'] = (None, "URL to access the repository")
         self.options['version_file'] = (None, "File containing name of most recent tarball version tested")
+        self.options['mpi_name'] = (None, "Name of OMPI tarball being tested")
         return
 
     def activate(self):
@@ -209,6 +211,8 @@ class OMPI_Snapshot(FetchMTTTool):
         log['status'] = status
         log['stdout'] = stdout
         log['stderr'] = stderr
+        log['mpi_info'] = {'name' : cmds['mpi_name'], 'version' : snapshot_req.text.strip()}
+        testDef.logger.verbose_print("setting mpi_info to " + str(log.get('mpi_info')))
 
         # log our absolute location so others can find it
         log['location'] = os.getcwd()


### PR DESCRIPTION
The Open MPI project has a particular way they like
to specify the MPI name and version.  Go to

https://mtt.open-mpi.org/

and click on the "summary" key.

This commit adds the ability to specify the "MPI name"
and "MPI version" within the OMPI snapshot plugin.

The autotools plugin is modified to check if
the mpi_name and version key's are already present
in the global log dictionary of dictionaries.  If
present, don't set in the autotools plugin.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>