### PR TITLE
Added switches to pymtt for using harasser

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -115,6 +115,15 @@ execGroup.add_argument("--duration",
 execGroup.add_argument("--loopforever", dest="loopforever",
                      action="store_true", default=False,
                      help="Causes MTT to continue to loop forever running same set of tests. Use this in conjunction with --duration switch to loop for a specific amount of time.")
+execGroup.add_argument("--harass_trigger",
+                     dest="harass_trigger_scripts", default=None,
+                     help="Paths to scripts that are run to harass the system while the test is running.")
+execGroup.add_argument("--harass_stop",
+                     dest="harass_stop_scripts", default=None,
+                     help="Paths to scripts that are run to stop harassing the system after the test finishes.")
+execGroup.add_argument("--harass_join_timeout",
+                     dest="harass_join_timeout", default=None,
+                     help="Number of seconds to wait while ending harass scripts. Default is infinity.")
 
 debugGroup = parser.add_argument_group('debugGroup', 'Debug Options')
 debugGroup.add_argument("-d", "--debug", dest="debug",

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -78,6 +78,17 @@ class SequentialEx(ExecutorMTTTool):
             testDef.watchdog.activate()
             testDef.watchdog.start()
 
+        # Start harasser
+        if testDef.options["harass_trigger_scripts"] is not None:
+            stageLog = {'section':"DefaultHarasser"}
+            testDef.harasser.execute(stageLog,{"trigger_scripts": testDef.options["harass_trigger_scripts"],
+                                  "stop_scripts": testDef.options["harass_stop_scripts"],
+                                  "join_timeout": testDef.options["harass_join_timeout"]}, testDef)
+            if stageLog['status'] != 0:
+                status = 1
+                only_reporter = True
+            testDef.logger.logResults("DefaultHarasser", stageLog)
+
         for step in testDef.loader.stageOrder:
             for title in testDef.config.sections():
                 if only_reporter and step != "Reporter":
@@ -321,7 +332,6 @@ class SequentialEx(ExecutorMTTTool):
                     status = 1
                     only_reporter = True
                     continue
-
 
         for p in testDef.stages.getAllPlugins() \
                + testDef.tools.getAllPlugins() \

--- a/pylib/Tools/Harasser/Harasser.py
+++ b/pylib/Tools/Harasser/Harasser.py
@@ -154,7 +154,7 @@ class Harasser(HarasserMTTTool):
 
         for (process,ops,starttime),(status,stdout,stderr,time) in zip(process_info,return_info):
             if status == 0:
-                process.join(self.options['join_timeout'][0])
+                process.join(int(self.options['join_timeout'][0]))
             elif status == 1:
                 process.terminate()
 


### PR DESCRIPTION
Switches are: --harass_trigger, --harass_stop, --harass_join_timeout
sequential executor modified to start and stop harasser using these switches as input

Also combined functionality between starting Combinatorial and Sequential executors
from TestDef so that way new functionality can be added without the two diverging
