### PR TITLE
OpenMPI plugin: observe timeout setting

### DIFF
--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -306,6 +306,9 @@ class OpenMPI(LauncherMTTTool):
         if cmds['hostfile'] is not None:
             cmdargs.append("-hostfile")
             cmdargs.append(cmds['hostfile'])
+        if cmds['timeout'] is not None:
+            cmdargs.append("--timeout")
+            cmdargs.append(cmds['timeout'])
         # cycle thru the list of tests and execute each of them
         log['testresults'] = []
         finalStatus = 0


### PR DESCRIPTION
The OpenMPI plugin wasn't actually adding a --timeout val
to the mpirun command line even if a users ini file
had the timeout value set.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>