### PR TITLE
JunitXML more readable xml output

### DIFF
--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -73,11 +73,11 @@ class JunitXML(ReporterMTTStage):
         time = 0
         for lg in fullLog:
             try:
-                stdout = lg['stdout']
+                stdout = "\n".join(lg['stdout'])
             except KeyError:
                 stdout = None
             try:
-                stderr = lg['stderr']
+                stderr = "\n".join(lg['stderr'])
             except KeyError:
                 stderr = None
             try:


### PR DESCRIPTION
stdout and stderr had unreadable raw python list format
New format is newline delimited which is more readable