### PR TITLE
Added proper encoding for string conversion

### DIFF
--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -516,6 +516,8 @@ class TestDef(object):
     def fill_log_interpolation(self, basestr, sublog):
         if isinstance(sublog, str):
             self.config.set("LOG", basestr, sublog.replace("$","$$"))
+        elif isinstance(sublog, unicode):
+            self.fill_log_interpolation(basestr, sublog.encode("utf-8", "ignore"))
         elif isinstance(sublog, dict):
             for k,v in sublog.items():
                 self.fill_log_interpolation("%s.%s" % (basestr, k), v)


### PR DESCRIPTION
In the fill_log_interpolation() function in TestDef, a string conversion
was failing due to not having the proper encoding. I fixed that