### PR TITLE
Refactor plugin loading to use pathlib

### DIFF
--- a/pyenv.txt
+++ b/pyenv.txt
@@ -12,5 +12,7 @@ virtualenvwrapper==4.7.1
 wheel==0.26.0
 Yapsy==1.11.223
 junit_xml==1.6
+pathlib==1.0.1
+python-hostlist==1.17
 future
 configparser

--- a/pylib/System/LoadClasses.py
+++ b/pylib/System/LoadClasses.py
@@ -15,6 +15,7 @@ import imp
 import sys
 import datetime
 from bisect import *
+from pathlib import Path
 
 class LoadClasses(object):
     def __init__(self):
@@ -28,42 +29,28 @@ class LoadClasses(object):
         return "LoadClasses"
 
     def load(self, directory):
-        oldcwd = os.getcwd()
-        os.chdir(directory)   # change our working dir
-        for filename in os.listdir(directory):
-            # if this filename is a directory, then recurse into it
-            if os.path.isdir(filename):
-                filename = os.path.join(directory, filename)
-                self.load(filename)
+        # Loop over every python file which has MTT in the
+        # filename in this directory tree
+        for filename in Path(directory).glob("**/*MTT*.py"):
+            # Strip file extension
+            modname = filename.stem
+
+            # Do this on the stem because it is a string
+            if "Stage" not in modname and "Tool" not in modname and "Utility" not in modname:
                 continue
-            # we require an "MTT" to be in the name of all
-            # class files to distinguish them from anything else
-            if "MTT" not in filename:
-                continue
-            # class files must end in ".py" - this helps us
-            # avoid the compiled version of Python files, which
-            # end in ".pyc"
-            if not filename.endswith(".py"):
-                continue
-            # To further distinguish the contents of the files,
-            # we separate them by function - therefore, we require
-            # that the filename indicate the functional category
-            # for the enclosed class
-            if "Stage" not in filename and "Tool" not in filename and "Utility" not in filename:
-                continue
-            # import/load the class from the file
-            modname = filename[:-3]
+
             try:
-                m = imp.load_source(modname, filename)
+                # Python 2 requires string cast
+                m = imp.load_source(modname, str(filename))
             except ImportError:
-                print("ERROR: unable to load " + modname + " from file " + filename)
+                print("ERROR: unable to load " + modname + " from file " + str(filename))
                 exit(1)
             # add the class to the corresponding category
             try:
                 cls = getattr(m, modname)
                 a = cls()
                 if "Stage" in modname:
-                    # trim the MTTClass from the name - it was included
+                    # trim the MTTStage from the name - it was included
                     # solely to avoid confusion with global namespaces
                     modname = modname[:-8]
                     self.stages[modname] = a.__class__
@@ -87,4 +74,3 @@ class LoadClasses(object):
             except AttributeError:
                 # just ignore it
                 continue
-        os.chdir(oldcwd)

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -24,6 +24,7 @@ from yapsy.PluginManager import PluginManager
 import datetime
 from distutils.spawn import find_executable
 from threading import Semaphore
+from pathlib import Path
 
 is_py2 = sys.version[0] == '2'
 
@@ -257,19 +258,17 @@ class TestDef(object):
                 # class definition
                 plugindirs.insert(0, y)
 
-        # Traverse the plugin directory tree and add all
-        # the class definitions we can find
+        # Load plugins from each of the specified plugin dirs
         for dirPath in plugindirs:
+            if not Path(dirPath).exists():
+                print("Attempted to load plugins from non-existent path:", dirPath)
+                continue
             try:
-                filez = os.listdir(dirPath)
-                for file in filez:
-                    file = os.path.join(dirPath, file)
-                    if os.path.isdir(file):
-                        self.loader.load(file)
-            except:
-                if not self.options['ignoreloadpatherrs']:
-                    print("Plugin directory",dirPath,"not found")
-                    sys.exit(1)
+                self.loader.load(dirPath)
+            except Exception as e:
+                print("Exception caught while loading plugins:")
+                print(e)
+                sys.exit(1)
 
         # Build the stages plugin manager
         self.stages = PluginManager()


### PR DESCRIPTION
This fixes an issue where relative plugin directories would not load
correctly. Furthermore, it simplifies the flow of the program
significantly, making it much more readable.
The changes to TestDef.py also fix an issue where the error reported was
not always the error which occurred. In addition to catching
non-existent directories, it caught any error which occurred in
LoadClasses.load() and gave unhelpful responses.
Per a conversation with @rhc54 , plugins in the given plugin
directories will be loaded, as opposed to just their subdirectories.

pathlib and hostlist were added to pyenv.txt. pathlib was included as
it is not standard in python <= 3.4. hostlist was an existing
requirement which was not in pyenv.txt.

I chose to use pathlib as it is much more concise and readable for some operations (such as getting all files in a tree matching a basic pattern) than os.path. The documentation for the pre-python3.4 version is available at https://pathlib.readthedocs.io/en/pep428/, and the post-3.4 documentation is on https://docs.python.org.

Tested with python 3.6.5 and python 2.7.9

Signed-off-by: Peter Gottesman <pgottesm@cisco.com>