### PR TITLE
Added missing yapsy-plugin file for OMPI_Snapshot

### DIFF
--- a/pylib/Tools/Fetch/OMPI_Snapshot.yapsy-plugin
+++ b/pylib/Tools/Fetch/OMPI_Snapshot.yapsy-plugin
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2018 Cisco Systems, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+[Core]
+Name = OMPI_Snapshot Plugin
+Module = OMPI_Snapshot
+
+[Documentation]
+Author = Howard Pritchard
+Version = 0.1
+Website = N/A
+Description = Plugin for getting software via OMPI Nightly tarballs


### PR DESCRIPTION
Fixes #675

Signed-off-by: Peter Gottesman <pgottesm@cisco.com>

@hppritcha I added you as the author because that is what I got from the git log. Can you confirm that is the case? I am just a bit confused by the 2015 intel copyright date.