### PR TITLE
Set "Doxygen" button to use correct url

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -27,7 +27,7 @@
         <div class="codeinfo">
           <ul>
             <li><a href="{{ site.github.repository_url }}" class="button"><strong>View On GitHub</strong></a></li>
-            <li><a href="https://jagaskak.github.io/mtt/html/index.html" class="button"><strong>Doxygen</strong></a></li>
+            <li><a href="{{ site.github.url }}/html/index.html" class="button"><strong>Doxygen</strong></a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Fixed based on this documentation: https://help.github.com/articles/repository-metadata-on-github-pages/

@Jagaskak is there a way to confirm the fix? I'm not very Travis-y.