### PR TITLE
Minor updates

### DIFF
--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -99,7 +99,7 @@ class JunitXML(ReporterMTTStage):
         # TODO:  Pull in the resource manager jobid.
         jobid = "job1"
         ts = TestSuite(jobid, testCases)
-        print(TestSuite.to_xml_string([ts]).encode('utf-8'), file=self.fh)
+        print(TestSuite.to_xml_string([ts]), file=self.fh)
 
         if cmds['filename'] is not None:
             self.fh.close()

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -90,6 +90,7 @@ class ExecuteCmd(BaseMTTUtility):
 
         # it is possible that the command doesn't exist or
         # isn't in our path, so protect us
+        p = None
         try:
             if time_exec:
                 starttime = datetime.datetime.now()
@@ -142,9 +143,11 @@ class ExecuteCmd(BaseMTTUtility):
             testDef.logger.verbose_print("ExecuteCmd done%s" % (": elapsed=%s"%elapsed_datetime if time_exec else ""), \
                                          timestamp=endtime if time_exec else None)
 
-        except OSError as e:
-            return (1, None, str(e), elapsed_secs)
+            p.wait()
 
-        p.wait()
+        except OSError as e:
+            if p:
+                p.wait()
+            return (1, None, str(e), elapsed_secs)
 
         return (p.returncode, stdout[stdoutlines:], stderr[stderrlines:], elapsed_secs)

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -116,19 +116,19 @@ class ExecuteCmd(BaseMTTUtility):
                     if fd == p.stdout.fileno():
                         read = p.stdout.readline()
                         if read:
-                            read = read.rstrip()
-                            testDef.logger.verbose_print('stdout: ' + read.decode("utf-8", errors='replace'))
+                            read = read.decode('utf-8').rstrip()
+                            testDef.logger.verbose_print('stdout: ' + read)
                             if merge:
-                                stderr.append(read.decode("utf-8", errors='replace'))
+                                stderr.append(read)
                             else:
-                                stdout.append(read.decode("utf-8", errors='replace'))
+                                stdout.append(read)
                             stdout_done = False
                     elif fd == p.stderr.fileno():
                         read = p.stderr.readline()
                         if read:
-                            read = read.rstrip()
-                            testDef.logger.verbose_print('stderr: ' + read.decode("utf-8", errors='replace'))
-                            stderr.append(read.decode("utf-8", errors='replace'))
+                            read = read.decode('utf-8').rstrip()
+                            testDef.logger.verbose_print('stderr: ' + read)
+                            stderr.append(read)
                             stderr_done = False
 
                 if stdout_done and stderr_done:

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -36,6 +36,27 @@ class ExecuteCmd(BaseMTTUtility):
             print(prefix + line)
         return
 
+    def _bool_option(self, options, name):
+        if options and name in options:
+            val = options[name]
+            if type(val) is bool:
+                return val
+            elif type(val) is str:
+                val = val.strip().lower()
+                return val in ['y', 'yes', 't', 'true', '1']
+            else:
+                return val > 0
+
+        return False
+
+    def _positive_int_option(self, options, name):
+        val = None
+        if options and name in options:
+            val = options[name]
+        if val is None or val < 0:
+            return 0
+        return int(val)
+
     def execute(self, options, cmdargs, testDef):
         # if this is a dryrun, just declare success
         if 'dryrun' in testDef.options and testDef.options['dryrun']:
@@ -43,36 +64,17 @@ class ExecuteCmd(BaseMTTUtility):
 
         #  check the options for a directive to merge
         # stdout into stderr
-        try:
-            if options['merge_stdout_stderr']:
-                merge = True
-            else:
-                merge = False
-        except:
-            merge = False
+        merge = self._bool_option(options, 'merge_stdout_stderr')
+
         # check for line limits
-        try:
-            if options['stdout_save_lines'] is None or options['stdout_save_lines'] < 0:
-                stdoutlines = 0
-            else:
-                stdoutlines = -1 * int(options['stdout_save_lines'])
-        except:
-            stdoutlines = 0
-        try:
-            if options['stderr_save_lines'] is None or options['stderr_save_lines'] < 0:
-                stderrlines = 0
-            else:
-                stderrlines = -1 * int(options['stderr_save_lines'])
-        except:
-            stderrlines = 0
+        stdoutlines = self._positive_int_option(options, 'stdout_save_lines')
+        stderrlines = self._positive_int_option(options, 'stderr_save_lines')
+
         # check for timing request
-        try:
-            if options['cmdtime'] or options['time']:
-                time_exec = True
-            else:
-                time_exec = False
-        except:
-            time_exec = False
+        t1 = self._bool_option(options, 'cmdtime')
+        t2 = self._bool_option(options, 'time')
+        time_exec = t1 or t2
+
         elapsed_secs = -1
         elapsed_datetime = None
 
@@ -150,4 +152,7 @@ class ExecuteCmd(BaseMTTUtility):
                 p.wait()
             return (1, None, str(e), elapsed_secs)
 
-        return (p.returncode, stdout[stdoutlines:], stderr[stderrlines:], elapsed_secs)
+        return (p.returncode,
+                stdout[-1 * stdoutlines:],
+                stderr[-1 * stderrlines:],
+                elapsed_secs)

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -38,11 +38,9 @@ class ExecuteCmd(BaseMTTUtility):
 
     def execute(self, options, cmdargs, testDef):
         # if this is a dryrun, just declare success
-        try:
-            if testDef.options['dryrun']:
-                return (0, None, None)
-        except KeyError:
-            pass
+        if 'dryrun' in testDef.options and testDef.options['dryrun']:
+            return (0, None, None, 0)
+
         #  check the options for a directive to merge
         # stdout into stderr
         try:

--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -104,13 +104,13 @@ class Logger(BaseMTTUtility):
         self.stage_start[stagename] = datetime.datetime.now()
         if self.printout:
             print(("%sStart executing [%s] plugin=%s" % ("%s "%self.stage_start[stagename] if self.sectimestamp else "",
-                                                            stagename, pluginname)).encode("utf-8"), file=self.fh)
+                                                            stagename, pluginname)), file=self.fh)
 
     def stage_end_print(self, stagename, pluginname, log):
         stage_end = datetime.datetime.now()
         if self.printout:
             print(("%sDone executing [%s] plugin=%s elapsed=%s" % ("%s "%stage_end if self.sectimestamp else "",
-                                                           stagename, pluginname, stage_end-self.stage_start[stagename])).encode("utf-8"), file=self.fh)
+                                                           stagename, pluginname, stage_end-self.stage_start[stagename])), file=self.fh)
         log['time'] = (stage_end-self.stage_start[stagename]).total_seconds()
         log['time_start'] = self.stage_start[stagename]
         log['time_end'] = stage_end
@@ -118,7 +118,7 @@ class Logger(BaseMTTUtility):
     def verbose_print(self, string, timestamp=None):
         if self.printout:
             print(("%s%s" % ("%s "%(datetime.datetime.now() if timestamp is None else timestamp) \
-                            if (self.timestampeverything or timestamp) else "", string)).encode("utf-8"), file=self.fh)
+                            if (self.timestampeverything or timestamp) else "", string)), file=self.fh)
         return
 
     def timestamp(self):

--- a/pylib/Utilities/MPIVersion.py
+++ b/pylib/Utilities/MPIVersion.py
@@ -97,12 +97,10 @@ class MPIVersion(BaseMTTUtility):
 #include <mpi.h>
 #include <stdio.h>
 int main(int argc, char **argv) {
-    MPI_Init(NULL, NULL);
     char version[3000];
     int resultlen;
     MPI_Get_library_version(version, &resultlen);
-    printf("%s", version);
-    MPI_Finalize();
+    printf("%s\\n", version);
     return 0;
 }""")
             fh.close()


### PR DESCRIPTION
A series of small commits for minor fixes that Cisco came across while working to bring up the Python client on our internal MTT cluster.

We tested these with Python 3.6.5 and 2.7.9.

@ribab Two notes for you:

1. We fixed a minor bug where child processes could be orphaned.
1. I see that the logging *always* encodes the output in utf-8.  Is there a reason for that?
    * I asked @rhc54 that question earlier today and he thought there was a reason, but he couldn't remember what it was.
    * @PeterGottesman and I talked about this on the phone; he initially thought it was a Python 2-vs-3 compatibility issue, but we determined that it isn't.
    * I *assume* that the utf-8 encoding isn't (or: is no longer) necessary, so one of the commits in here takes it out.  We noticed this because it makes weird output with python 3 -- a bunch (but not all) of the MTT output is enclosed in `b''`.  Let me know if we need to do something different.