### PR TITLE
Fixed return values of ExecuteCmd, and with how TextFile reporter interprets them

### DIFF
--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -55,6 +55,12 @@ class TextFile(ReporterMTTStage):
             print(prefix + line)
         return
 
+    def _print_stderr_block(self, name, lines, tabs=1):
+        if lines:
+            print("\t"*tabs,"ERROR ({name})".format(name=name), file=self.fh)
+            for l in lines:
+                print("\t"*(tabs),"   ",l, file=self.fh)
+
     def execute(self, log, keyvals, testDef):
         testDef.logger.verbose_print("TextFile Reporter")
         # pickup the options
@@ -87,13 +93,10 @@ class TextFile(ReporterMTTStage):
                 except KeyError:
                     pass
                 if 0 != lg['status']:
-                    try:
-                        print("\tERROR:",lg['stderr'], file=self.fh)
-                    except KeyError:
-                        try:
-                            print("\tERROR:",lg['stdout'], file=self.fh)
-                        except KeyError:
-                            pass
+                    if "stderr" in lg:
+                        self._print_stderr_block("stderr", lg['stderr'], tabs=1)
+                    if "stdout" in lg:
+                        self._print_stderr_block("stdout", lg['stdout'], tabs=1)
             except KeyError:
                 pass
             try:
@@ -134,7 +137,10 @@ class TextFile(ReporterMTTStage):
                         tname = os.path.basename(test['test'])
                         print("\t\t",tname,"  Status:",test['status'], file=self.fh)
                         if 0 != test['status']:
-                            print("\t\t\t","Stderr:",test['stderr'], file=self.fh)
+                            if "stderr" in test:
+                                self._print_error_block("stderr", test['stderr'], tabs=3)
+                            if "stdout" in test:
+                                self._print_error_block("stdout", test['stdout'], tabs=3)
             except KeyError:
                 pass
             print(file=self.fh)

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -60,7 +60,7 @@ class ExecuteCmd(BaseMTTUtility):
     def execute(self, options, cmdargs, testDef):
         # if this is a dryrun, just declare success
         if 'dryrun' in testDef.options and testDef.options['dryrun']:
-            return (0, None, None, 0)
+            return (0, [], [], 0)
 
         #  check the options for a directive to merge
         # stdout into stderr
@@ -88,7 +88,7 @@ class ExecuteCmd(BaseMTTUtility):
 
         if not mycmdargs:
             testDef.logger.verbose_print("ExecuteCmd error: no cmdargs")
-            return (1, None, "MTT ExecuteCmd error: no cmdargs", 0)
+            return (1, [], ["MTT ExecuteCmd error: no cmdargs"], 0)
 
         # it is possible that the command doesn't exist or
         # isn't in our path, so protect us
@@ -150,7 +150,7 @@ class ExecuteCmd(BaseMTTUtility):
         except OSError as e:
             if p:
                 p.wait()
-            return (1, None, str(e), elapsed_secs)
+            return (1, [], [str(e)], elapsed_secs)
 
         return (p.returncode,
                 stdout[-1 * stdoutlines:],


### PR DESCRIPTION
Fixes #685

Now if an error happens in the code, the return value will still be a list

Signed-off-by: Richard Barella <richard.t.barella@intel.com>