### PR TITLE
Fixes #674 -- scratch for writing reporter files

### DIFF
--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -57,7 +57,8 @@ class JunitXML(ReporterMTTStage):
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
         if cmds['filename'] is not None:
-            self.fh = open(cmds['filename'], 'w')
+            self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
+                           else os.path.join(cmds['scratch'],cmds['filename']), 'w')
         if testDef.options['description'] is not None:
             print(testDef.options['description'], file=self.fh)
             print(file=self.fh)

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -68,7 +68,8 @@ class TextFile(ReporterMTTStage):
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
         if cmds['filename'] is not None:
-            self.fh = open(cmds['filename'], 'w')
+            self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
+                           else os.path.join(cmds['scratch'],cmds['filename']), 'w')
         if testDef.options['description'] is not None:
             print(testDef.options['description'], file=self.fh)
             print(file=self.fh)

--- a/tests/bat/default_check_profile.ini
+++ b/tests/bat/default_check_profile.ini
@@ -7,7 +7,7 @@ scratch = mttscratch
 [TestGet:Environ]
 plugin = Environ
 KERNEL_RELEASE = ${ENV:KERNEL_VERSION}
-LOGFILE = profile.report.txt
+LOGFILE = ../profile.report.txt
 
 [TestGet:KernelRelease]
 # Don't use the stage name "Profile" in the test label.

--- a/tests/bat/default_check_profile.sh
+++ b/tests/bat/default_check_profile.sh
@@ -10,5 +10,5 @@ logfile=${LOGFILE:? LOGFILE not set}
 # Check that the logfile has correct version string
 # Remove the line in the logfile that was used for passing in KERNEL_RELEASE environment variable
 # The logfile will live at the top of the <scratchdir>/<testname> directory structure
-cat ../../$logfile | grep -v KERNEL_RELEASE | grep $kernel_release
+cat $logfile | grep -v KERNEL_RELEASE | grep $kernel_release
 exit $?


### PR DESCRIPTION
TextFile plugin and JunitXML plugin now write to the pre-defined scratch directory