### PR TITLE
Related to #695 Remove unneeded print of plugin-name for harasser

### DIFF
--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -337,7 +337,6 @@ class TestDef(object):
         # Configure harasser plugin
         print(self.tools.getPluginsOfCategory("Harasser"))
         for pluginInfo in self.tools.getPluginsOfCategory("Harasser"):
-            print(pluginInfo.plugin_object.print_name())
             if "Harasser" == pluginInfo.plugin_object.print_name():
                 self.harasser = pluginInfo.plugin_object
                 break


### PR DESCRIPTION
This was a confusing output that made it seem like something was wrong when everything was working fine