### PR TITLE
Only deploy gh-pages when something did change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,15 +66,16 @@ script:
   - $TRAVIS_BUILD_DIR/pyclient/pymtt.py --verbose $TRAVIS_BUILD_DIR/tests/bat/default_check_profile.ini
 
 before_deploy:
-  - cd docs && doxygen Doxyfile
+  - cd docs && doxygen Doxyfile && cd ..
+
 deploy:
-  provider: pages
+  provider: script
+  script: sh scripts/deploy.sh
   skip_cleanup: true
-  github-token: $GH_TOKEN
-  local_dir: docs/
-  keep-history: true
   on:
     branch: master
+    python: 2.7
+
 after_success:
 env:
   matrix:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+git clone --depth=1 -b gh-pages https://github.com/open-mpi/mtt.git gh-pages
+tar -C docs -cf - . | tar -C gh-pages -xf -
+
+cd gh-pages
+
+git add html
+
+if git diff --exit-code --quiet html > /dev/null 2>&1; then
+    echo NOTHING TO PUSH
+else
+    echo PUSHING CHANGES
+    git add .
+    git commit -m "Deploy updated open-mpi/mtt to gh-pages"
+    git push https://$GH_TOKEN@github.com/open-mpi/mtt.git gh-pages
+fi


### PR DESCRIPTION
Since the generated latex files have some timestamps,
manually update the gh-pages branch only if something has
changed in the docs/html directory.

The script/deploy.sh script does some extra steps (e.g. git clone)
in order to preserve the history on the gh-pages branches.

If we do not care about history, this step can be skipped and we can simply

git init; git push --force ...

note the GH_USER variable is currently hardcoded, and it might have to/could
be changed and/or encrypted (with GH_TOKEN)

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>