### PR TITLE
deploy.sh: fix minor git command typo

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+#
+# Copyright (c) 2018 Cisco Systems, Inc.  All rights reserved.
+#
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
 
 git clone --depth=1 -b gh-pages https://github.com/open-mpi/mtt.git gh-pages
 tar -C docs -cf - . | tar -C gh-pages -xf -
@@ -7,7 +14,7 @@ cd gh-pages
 
 git add html
 
-if git diff --exit-code --quiet html > /dev/null 2>&1; then
+if git diff --cached --exit-code html > /dev/null 2>&1; then
     echo NOTHING TO PUSH
 else
     echo PUSHING CHANGES


### PR DESCRIPTION
Per https://github.com/open-mpi/mtt/pull/711#issuecomment-417831702,
update the git command that checks for changes.

Also add a copyright header to this file (others didn't add their
copyrights -- tsk, tsk -- so it looks like Cisco is the only copyright
holder, even though Cisco isn't the original author of this file).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>