### PR TITLE
Duration metrics

### DIFF
--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -149,9 +149,9 @@ class TextFile(ReporterMTTStage):
             except KeyError:
                 pass
             print(file=self.fh)
-        if cmds['filename'] is not None:
-            self.fh.close()
         print("Num sections pass:",num_secs_pass,"/",len(fullLog),"sections", file=self.fh)
         print("Percentage sections pass:",100*float(num_secs_pass)/float(len(fullLog)), file=self.fh)
+        if cmds['filename'] is not None:
+            self.fh.close()
         log['status'] = 0
         return

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -64,6 +64,7 @@ class TextFile(ReporterMTTStage):
 
     def execute(self, log, keyvals, testDef):
         testDef.logger.verbose_print("TextFile Reporter")
+        num_secs_pass = 0
         # pickup the options
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
@@ -99,6 +100,8 @@ class TextFile(ReporterMTTStage):
                         self._print_stderr_block("stderr", lg['stderr'], tabs=1)
                     if "stdout" in lg:
                         self._print_stderr_block("stdout", lg['stdout'], tabs=1)
+                else:
+                    num_secs_pass += 1
             except KeyError:
                 pass
             try:
@@ -148,5 +151,7 @@ class TextFile(ReporterMTTStage):
             print(file=self.fh)
         if cmds['filename'] is not None:
             self.fh.close()
+        print("Num sections pass:",num_secs_pass,"/",len(fullLog),"sections", file=self.fh)
+        print("Percentage sections pass:",100*float(num_secs_pass)/float(len(fullLog)), file=self.fh)
         log['status'] = 0
         return

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -636,7 +636,7 @@ class TestDef(object):
                 self.logger.verbose_print(self.config.items(section))
         return
 
-    def executeTest(self, enable_loop=True, executor="sequential"):
+    def executeTest(self, executor="sequential"):
 
         if not self.loaded:
             print("Plugins have not been loaded - cannot execute test")
@@ -655,15 +655,10 @@ class TestDef(object):
         if status == 0 and self.options['clean_after'] and os.path.isdir(self.options['scratchdir']):
             self.logger.verbose_print("Cleaning up scratchdir after successful run")
             shutil.rmtree(self.options['scratchdir'])
-        # Loop forever if specified
-        if enable_loop and self.options['loopforever']:
-            while True:
-                self.logger.reset()
-                self.executeTest(enable_loop=False, executor=executor)
         return status
 
-    def executeCombinatorial(self, enable_loop=True):
-        return self.executeTest(enable_loop=enable_loop, executor="combinatorial")
+    def executeCombinatorial(self):
+        return self.executeTest(executor="combinatorial")
   
     def printOptions(self, options):
         # if the options are empty, report that

--- a/pylib/Utilities/Watchdog.py
+++ b/pylib/Utilities/Watchdog.py
@@ -48,10 +48,12 @@ class Watchdog(BaseMTTUtility):
         return
 
     # Start the watchdog timer
-    def start(self):
+    def start(self, handler=None):
+        if handler is None:
+            handler = self.defaultHandler
         if not self.timer or not self.timer.is_alive():
             self.timer = Timer(int(self.timeout.total_seconds()),
-                               self.defaultHandler)
+                               handler)
             self.timer.start()
 
     # Stop the watchdog timer


### PR DESCRIPTION
When --duration switch is used along with --loopforever switch,
MTT will run an INI file over and over for a duration

This change enhances that and enables a metric of #stages that pass/fail
to be reported in TextFile and JunitXML reporters