### PR TITLE
Can now change the name of the scratch directory

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -82,7 +82,7 @@ execGroup.add_argument("--plugin-dir", dest="plugindir",
                      help="Specify the DIRECTORY where additional plugins can be found (or comma-delimited list of DIRECTORYs)", metavar="DIRECTORY")
 execGroup.add_argument("--ignore-loadpath-errors", action="store_true", dest="ignoreloadpatherrs", default=False,
                      help="Ignore errors in plugin paths")
-execGroup.add_argument("--scratch-dir", dest="scratchdir", default="./mttscratch",
+execGroup.add_argument("--scratch-dir", dest="scratchdir", default=None,
                      help="Specify the DIRECTORY under which scratch files are to be stored", metavar="DIRECTORY")
 execGroup.add_argument("--print-section-time", dest="sectime",
                       action="store_true", default=True,
@@ -224,7 +224,6 @@ a = cls()
 
 # create the Test Definition object and set the
 # options and arguments
-# create the scratch directory
 testDef = a.__class__();
 testDef.setOptions(args)
 

--- a/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
+++ b/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
@@ -19,7 +19,7 @@ from MTTDefaultsMTTStage import *
 # @section DefaultMTTDefaults
 # Store any provided default MTT settings
 # @param trial                 Use when testing your MTT client setup; results that are generated and submitted to the database are marked as \"trials\" and are not included in normal reporting.
-# @param scratch               Specify the DIRECTORY under which scratch files are to be stored
+# @param scratchdir            Specify the DIRECTORY under which scratch files are to be stored
 # @param description           Provide a brief title/description to be included in the log for this test
 # @param platform              Name of the system under test
 # @param organization          Name of the organization running the test
@@ -36,7 +36,7 @@ class DefaultMTTDefaults(MTTDefaultsMTTStage):
         MTTDefaultsMTTStage.__init__(self)
         self.options = {}
         self.options['trial'] = (False, "Use when testing your MTT client setup; results that are generated and submitted to the database are marked as \"trials\" and are not included in normal reporting.")
-        self.options['scratch'] = ("./mttscratch", "Specify the DIRECTORY under which scratch files are to be stored")
+        self.options['scratchdir'] = ("./mttscratch", "Specify the DIRECTORY under which scratch files are to be stored")
         self.options['description'] = (None, "Provide a brief title/description to be included in the log for this test")
         self.options['platform'] = (None, "Name of the system under test")
         self.options['organization'] = (None, "Name of the organization running the test")

--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -58,7 +58,7 @@ class JunitXML(ReporterMTTStage):
         testDef.parseOptions(log, self.options, keyvals, cmds)
         if cmds['filename'] is not None:
             self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
-                           else os.path.join(cmds['scratch'],cmds['filename']), 'w')
+                           else os.path.join(cmds['scratchdir'],cmds['filename']), 'w')
         if testDef.options['description'] is not None:
             print(testDef.options['description'], file=self.fh)
             print(file=self.fh)

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -70,7 +70,7 @@ class TextFile(ReporterMTTStage):
         testDef.parseOptions(log, self.options, keyvals, cmds)
         if cmds['filename'] is not None:
             self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
-                           else os.path.join(cmds['scratch'],cmds['filename']), 'w')
+                           else os.path.join(cmds['scratchdir'],cmds['filename']), 'w')
         if testDef.options['description'] is not None:
             print(testDef.options['description'], file=self.fh)
             print(file=self.fh)

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -76,11 +76,6 @@ class TestDef(object):
     def setOptions(self, args):
         self.options = vars(args)
         self.args = args
-        # if they want us to clear the scratch, then do so
-        if self.options['clean'] and os.path.isdir(self.options['scratchdir']) :
-            shutil.rmtree(self.options['scratchdir'])
-        # setup the scratch directory
-        _mkdir_recursive(self.options['scratchdir'])
 
     # private function to convert values
     def __convert_value(self, opt, inval):
@@ -613,6 +608,22 @@ class TestDef(object):
         if sections is not None and 0 != len(sections) and not skip:
             print("ERROR: sections were specified for execution and not found:",sections)
             sys.exit(1)
+        # set Defaults -command line args supercede .ini args
+        try:
+            if not self.options['scratchdir']:
+                self.options['scratchdir'] = self.config.get('MTTDefaults', 'scratchdir')
+        except KeyError:
+                self.options['scratchdir'] = './mttscratch'
+        try:    
+            if not self.options['executor']:
+                self.options['executor'] = self.config.get('MTTDefaults', 'executor')
+        except KeyError:
+            self.options['executor'] = 'sequential'        
+        # if they want us to clear the scratch, then do so
+        if self.options['clean'] and os.path.isdir(self.options['scratchdir']) :
+            shutil.rmtree(self.options['scratchdir'])
+        # setup the scratch directory
+        _mkdir_recursive(self.options['scratchdir'])
         return
 
     # Used with combinatorial executor, loads next .ini file to be run with the

--- a/pylib/Tools/Build/Hostfile.py
+++ b/pylib/Tools/Build/Hostfile.py
@@ -103,7 +103,7 @@ class Hostfile(BuildMTTTool):
             log['stderr'] = "Parent not specified"
             return
         try:
-            parentloc = os.path.join(os.getcwd(),log['options']['scratch'])
+            parentloc = os.path.join(os.getcwd(),log['options']['scratchdir'])
             location = parentloc
         except KeyError:
             log['status'] = 1

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -149,7 +149,7 @@ class Shell(BuildMTTTool):
             log['stderr'] = "Parent not specified"
             return
         try:
-            parentloc = os.path.join(os.getcwd(),log['options']['scratch'])
+            parentloc = os.path.join(os.getcwd(),log['options']['scratchdir'])
             location = parentloc
         except KeyError:
             log['status'] = 1


### PR DESCRIPTION
The name of the scratch directory can now be changed in the MTTDefaults section of the .ini files or on the command line.

Fixes #722

Signed-off-by: Deb Rezanka <rezanka@lanl.gov>