### PR TITLE
Fixes #739 #738 #737 #736 scratchdir alignment

### DIFF
--- a/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
+++ b/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
@@ -78,6 +78,17 @@ class DefaultMTTDefaults(MTTDefaultsMTTStage):
                 del keyvals['scratch']
         except KeyError:
             pass
+
+        # overlaying ini defaults with command line arguments
+        for option in testDef.options:
+            if option in self.options and option in testDef.options:
+                keyvals[option] = testDef.options[option]
+
+        # setting unset command line arguments with ini defaults
+        for keyval in keyvals:
+            if keyval not in testDef.options:
+                testDef.options[keyval] = keyvals[keyval]
+
         # the parseOptions function will record status for us
         testDef.parseOptions(log, self.options, keyvals, cmds)
         # we need to record the results into our options so

--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -58,7 +58,7 @@ class JunitXML(ReporterMTTStage):
         testDef.parseOptions(log, self.options, keyvals, cmds)
         if cmds['filename'] is not None:
             self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
-                           else os.path.join(cmds['scratchdir'],cmds['filename']), 'w')
+                           else os.path.join(testDef.options['scratchdir'],cmds['filename']), 'w')
         if testDef.options['description'] is not None:
             print(testDef.options['description'], file=self.fh)
             print(file=self.fh)

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -70,7 +70,7 @@ class TextFile(ReporterMTTStage):
         testDef.parseOptions(log, self.options, keyvals, cmds)
         if cmds['filename'] is not None:
             self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
-                           else os.path.join(cmds['scratchdir'],cmds['filename']), 'w')
+                           else os.path.join(testDef.options['scratchdir'],cmds['filename']), 'w')
         if testDef.options['description'] is not None:
             print(testDef.options['description'], file=self.fh)
             print(file=self.fh)

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -149,7 +149,7 @@ class Shell(BuildMTTTool):
             log['stderr'] = "Parent not specified"
             return
         try:
-            parentloc = os.path.join(os.getcwd(),log['options']['scratchdir'])
+            parentloc = os.path.join(os.getcwd(), testDef.options['scratchdir'])
             location = parentloc
         except KeyError:
             log['status'] = 1

--- a/pylib/Utilities/ModuleCmd.py
+++ b/pylib/Utilities/ModuleCmd.py
@@ -62,22 +62,17 @@ class ModuleCmd(BaseMTTUtility):
                 if options['verbose'] or options['debug'] :
                     print("The --env-module-wrapper switch was not used and module python support via os.environ['MODULESHOME'] was not found")
                 return
-        try:
-            # scratchdir defaults to mttscratch if not set
-            self.env_module_link = os.path.join(options['scratchdir'], "env_modules_python.py")
-            if os.path.isfile(self.env_module_link) or os.path.islink(self.env_module_link):
-                os.remove(self.env_module_link)
-            # create a soft link that includes the .py extension; the tcl python module file does not include this
-            os.symlink(self.env_module_wrapper, self.env_module_link)
-        except:
-            print("Unable to link to " + self.env_module_wrapper)
-            print("Since we are unable to meet this basic user directive,")
-            print("we will now abort")
-            sys.exit(1)
+
+        # setting the link variable to the wrapper as we use it in other places
+        self.env_module_link = self.env_module_wrapper
+        if options['verbose'] or options['debug']:
+            print("Using env module wrapper:", self.env_module_link)
+
         return
 
     def loadModules(self, modules, testDef):
-        # Logging of results from the environment modules usage is the responsibility of the plugin that is making use of this utility.
+        # Logging of results from the environment modules usage is the responsibility
+        # of the plugin that is making use of this utility.
         if self.env_module_wrapper is None:
             # cannot perform this operation
             return (1, None, "Module capability was not found")


### PR DESCRIPTION
Removed the link to the env_modules_python and just use the actual file.
Command line args take precedence over ini
Removed other references to defaulting scratchdir to ./mttscratch,
leaving the one in TestDef.py
Cleaned up other plugins references to scratchdir to use TestDef.options
FYI: Ricky did alot of this work too.

Signed-off-by: Bill Weide <william.c.weide@intel.com>