### PR TITLE
Improve readability of MTT verbose output

### DIFF
--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -521,6 +521,7 @@ class TestDef(object):
             self.fill_log_interpolation(basestr, str(sublog))
 
     def configTest(self):
+
         # setup the configuration parser
         self.config = configparser.SafeConfigParser(interpolation=configparser.ExtendedInterpolation())
 
@@ -650,6 +651,8 @@ class TestDef(object):
         return
 
     def executeTest(self, executor="sequential"):
+
+        self.logger.print_cmdline_args(self)
 
         if not self.loaded:
             print("Plugins have not been loaded - cannot execute test")


### PR DESCRIPTION
- Spaces added between sections
- Section headers are more obvious
- cmdline args are printed at top of test run
- section options and cmdline args are printed line-by-line
  instead of all in one line