### PR TITLE
Fixes duration bug with interrupted copytree

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -120,9 +120,12 @@ execGroup.add_argument("--stop-on-fail", dest="stop_on_fail",
 execGroup.add_argument("--duration",
                      dest="duration", default=None,
                      help="Add a maximum duration for test before interrupting.")
+execGroup.add_argument("--loop",
+                     dest="loop", default=None,
+                     help="Causes MTT to loop until provided number of seconds finishes")
 execGroup.add_argument("--loopforever", dest="loopforever",
                      action="store_true", default=False,
-                     help="Causes MTT to continue to loop forever running same set of tests. Use this in conjunction with --duration switch to loop for a specific amount of time.")
+                     help="Causes MTT to continue to loop forever running same set of tests")
 execGroup.add_argument("--harass_trigger",
                      dest="harass_trigger_scripts", default=None,
                      help="Paths to scripts that are run to harass the system while the test is running.")

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -615,7 +615,8 @@ class TestDef(object):
             try:
                 self.options['scratchdir'] = self.config.get('MTTDefaults', 'scratch')
             except:
-                self.options['scratchdir'] = './mttscratch'
+                self.options['scratchdir'] = os.path.abspath('./mttscratch')
+        self.options['scratchdir'] = os.path.abspath(self.options['scratchdir'])
         try:
             if not self.options['executor']:
                 self.options['executor'] = self.config.get('MTTDefaults', 'executor')

--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -78,16 +78,18 @@ class Copytree(BaseMTTUtility):
         try:
             # Cleanup the target directory if it exists
             if os.path.exists(dst):
-                shutil.rmtree(dst)
-            os.mkdir(dst)
+                shutil.rmtree(dst, ignore_errors=True)
+            if not os.path.exists(dst):
+                os.mkdir(dst)
             for srcpath in cmds['src'].split(','):
                 srcpath = srcpath.strip()
                 reload(distutils.dir_util)
                 if cmds['preserve_directory'] != "0":
                     subdst = os.path.join(dst,os.path.basename(srcpath))
-                    if os.path.exists(subdst):
-                        shutil.rmtree(subdst)
-                    os.mkdir(subdst)
+                    while os.path.exists(subdst):
+                        shutil.rmtree(subdst, ignore_errors=True)
+                    if not os.path.exists(dst):
+                        os.mkdir(subdst)
                     distutils.dir_util.copy_tree(srcpath, subdst, preserve_symlinks=int(cmds['preserve_symlinks']))
                 else:
                     distutils.dir_util.copy_tree(srcpath, dst, preserve_symlinks=int(cmds['preserve_symlinks']))


### PR DESCRIPTION
- Duration switch interrupts things now
- Loop switch added that doesn't interrupt and continues looping
  for a specified amount of time
- Copytree fixed so it doesn't error out when directory cannot be removed