### PR TITLE
Since we now pass the description in, this is not needed

### DIFF
--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -59,9 +59,6 @@ class JunitXML(ReporterMTTStage):
         if cmds['filename'] is not None:
             self.fh = open(cmds['filename'] if os.path.isabs(cmds['filename']) \
                            else os.path.join(testDef.options['scratchdir'],cmds['filename']), 'w')
-        if testDef.options['description'] is not None:
-            print(testDef.options['description'], file=self.fh)
-            print(file=self.fh)
        
         # Use the Junit classname field to store the list of inifiles
         try:


### PR DESCRIPTION
Not sure why this was here originally, but it breaks the xml output and jenkins cannot read the file since  we fix sending the description with PR #757

Signed-off-by: Bill Weide <william.c.weide@intel.com>