### PR TITLE
Fixes version_file error crash in OMPI_Snapshot.py

### DIFF
--- a/pylib/Tools/Fetch/OMPI_Snapshot.py
+++ b/pylib/Tools/Fetch/OMPI_Snapshot.py
@@ -228,8 +228,9 @@ class OMPI_Snapshot(FetchMTTTool):
                     print(snapshot_req.text.strip(), file=f)
                 except:
                     log['status'] = 1
-                    log['stderr'] = "Failed to update version file"
-                    testDef.logger.verbose_print("Failed to update version file")
+                    log['stderr'] = "FAILED to update version file"
+                    testDef.logger.verbose_print("FAILED TO UPDATE VERSION FILE - EXITING")
+                    os.chdir(cwd)
                     return
         except KeyError:
             pass


### PR DESCRIPTION
When OMPI_Snapshot.py was given a path that did not exist it was
crashing because it did not set the path back correctly.  This
fixes it so it fails and exits gracefully and adds more obvious
output to verbose_print about why it exited.

Fixes #762

Signed-off-by: Deb Rezanka <rezanka@lanl.gov>