### PR TITLE
Doxypypy for doxygen interepreter

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -863,7 +863,7 @@ IMAGE_PATH             =
 # code is scanned, but not when the output code is generated. If lines are added
 # or removed, the anchors will not be placed correctly.
 
-INPUT_FILTER           = "doxypy.py"
+INPUT_FILTER           = "doxypypy"
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the


### PR DESCRIPTION
to get: pip install doxypypy

A more pythonic version of doxygen interpreter

Also, my system couldn't find old "doxypy.py" file