### PR TITLE
Add shell-mode to shell plugin

### DIFF
--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -51,6 +51,7 @@ class Shell(BuildMTTTool):
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
         self.options['asis_target'] = (None, "Specifies name of asis_target being built. This is used with \"ASIS\" keyword to determine whether to do anything.")
+        self.options['shell_mode'] = (False, "Use shlex or shell-mode for parsing?")
 
         self.allocated = False
         self.testDef = None
@@ -352,7 +353,10 @@ class Shell(BuildMTTTool):
         if False == self.allocate(log, cmds, testDef):
             return
 
-        cfgargs = shlex.split(cmds['command'])
+        if cmds['shell_mode'] is False:
+            cfgargs = shlex.split(cmds['command'])
+        else:
+            cfgargs = ["sh", "-c", cmds['command']]
 
         if 'TestRun' in log['section'].split(":")[0]:
             harass_exec_ids = testDef.harasser.start(testDef)

--- a/tests/bat/shell_mode.ini
+++ b/tests/bat/shell_mode.ini
@@ -1,0 +1,26 @@
+[MTTDefaults]
+description = Tests shell_mode feature in Shell plugin
+
+[TestRun:with_shell_mode]
+plugin = Shell
+shell_mode = true
+command = #!/bin/bash
+          echo "hi"
+          SOMEVAR=2
+          echo somevar: $$SOMEVAR
+          echo somevar+2: $$($$SOMEVAR + 2)
+
+[TestRun:without_shell_mode]
+plugin = Shell
+command = #!/bin/bash
+          echo "hi"
+          SOMEVAR=2
+          echo somevar: $$SOMEVAR
+          echo somevar+2: $$($$SOMEVAR + 2)
+fail_test = true
+
+
+
+[Reporter:JunitXML]
+plugin = JunitXML
+filename = default_check_profile.xml


### PR DESCRIPTION
Now you can run shell plugin just like you are running shell!

```
[TestRun:Example]
plugin = Shell
shell_mode = true
command = #!/bin/bash
          echo "hi"
          SOMEVAR=2
          echo somevar: $$SOMEVAR
          echo somevar+2: $$($$SOMEVAR + 2)

```