### PR TITLE
Fixes #744, removes --no-reporter, adds wildcard

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -20,6 +20,7 @@ import logging
 import imp
 from yapsy.PluginManager import PluginManager
 import argparse
+import shlex
 
 # First check for bozo error - we need to be given
 # at least a cmd line option, so no params at all
@@ -103,9 +104,6 @@ execGroup.add_argument("-s", "--sections", dest="section",
                      help="Execute the specified SECTION (or comma-delimited list of SECTIONs)", metavar="SECTION")
 execGroup.add_argument("--skip-sections", dest="skipsections",
                      help="Skip the specified SECTION (or comma-delimited list of SECTIONs)", metavar="SECTION")
-execGroup.add_argument("--no-reporter", dest="reporter",
-                      action="store_true", default=False,
-                      help="Do not invoke any MTT Reporter modules")
 execGroup.add_argument("-l", "--log", dest="logfile", default=None,
                      help="Log all output to FILE (defaults to stdout)", metavar="FILE")
 execGroup.add_argument("--group-results", dest="submit_group_results", default=True,
@@ -158,7 +156,7 @@ args = parser.parse_args()
 # any set on the command line.  Environment will override the commandline.
 mttArgs = []
 if 'MTT_ARGS' in os.environ and os.environ.get('MTT_ARGS') != None:
-    mttArgs = os.environ['MTT_ARGS'].split()
+    mttArgs = shlex.split(os.environ['MTT_ARGS'])
     args = parser.parse_args(sys.argv[1:] + mttArgs)
 
 # check to see if MTT_HOME has been set - we require it

--- a/pylib/System/test_TestDef.py
+++ b/pylib/System/test_TestDef.py
@@ -1,0 +1,179 @@
+# run this via pytest
+# export MTT_HOME=/home/wcweide/dev/mtt.forked
+# pytest ./test_TestDef.py
+#   add the -s argument to display print lines
+#   add the -v argument to be verbose
+# ie  pytest -sv ./test_TestDef.py
+import pytest
+import os
+import sys
+import configparser
+sys.path.append(os.path.join(os.environ['MTT_HOME'], "pylib/System"))
+import TestDef as TD
+
+def setup():
+   td = TD.TestDef()
+   td.config = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
+   td.config.optionxform = str
+   td.config.add_section('ENV')
+   td.config.add_section('LOG')
+   return td
+
+def test_expandWildCardsAtEnd():
+   td = setup()
+   td.config.add_section('Reporter:IUDatabase')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Reporter:*']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:IUDatabase' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsAtBeginning():
+   td = setup()
+   td.config.add_section('Reporter:IUDatabase')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['*IUDatabase']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:IUDatabase' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsInMiddle():
+   td = setup()
+   td.config.add_section('Reporter:IUDatabase')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Report*UDatabase']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:IUDatabase' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsInBigList():
+   td = setup()
+   td.config.add_section('Reporter:IUDatabase')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Report*UDatabase']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:IUDatabase' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsAtEndMultiple():
+   td = setup()
+   td.config.add_section('Reporter:IUDatabase')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Report*']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:IUDatabase' in expsections and 'Reporter:TextFile' in expsections and 'Reporter:JSONFile' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsAtBeginningMultiple():
+   td = setup()
+   td.config.add_section('Reporter:XMLFile')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['*File']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:XMLFile' in expsections and 'Reporter:TextFile' in expsections and 'Reporter:JSONFile' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsInMiddleMultiple():
+   td = setup()
+   td.config.add_section('Reporter:XMLFile')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Rep*File']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:XMLFile' in expsections and 'Reporter:TextFile' in expsections and 'Reporter:JSONFile' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsMultipleStars():
+   td = setup()
+   td.config.add_section('Reporter:XMLFile')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['*porter*File']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:XMLFile' in expsections and 'Reporter:TextFile' in expsections and 'Reporter:JSONFile' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsStarsAtBeginning():
+   td = setup()
+   td.config.add_section('Reporter:XMLFile')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['*Reporter:TextFile']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:TextFile' in expsections 
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsStarsAtEnd():
+   td = setup()
+   td.config.add_section('Reporter:XMLFile')
+   td.config.add_section('Reporter:TextFile')
+   td.config.add_section('Reporter:JSONFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Reporter:TextFile*']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:TextFile' in expsections 
+   print("--->expanded:", expsections) 
+
+# this fails
+#def test_expandWildCardsMultipleStarsInARow():
+#   td = setup()
+#   td.config.add_section('Reporter:TextFile')
+#   print("--->sections:", td.config.sections())
+#   assert td.config.sections() is not None
+#   sections = ['Report****File']
+#   print("--->to skip:", sections)
+#   expsections = td.expandWildCards(sections)
+#   assert 'Reporter:TextFile' in expsections
+#   print("--->expanded:", expsections) 
+
+def test_expandWildCardsMultipleStarsInARow():
+   td = setup()
+   td.config.add_section('Reporter:TextFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Report*:*ex*File']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:TextFile' in expsections
+   print("--->expanded:", expsections) 
+
+def test_expandWildCardsMultipleStarsInARowNoGaps():
+   td = setup()
+   td.config.add_section('Reporter:TextFile')
+   print("--->sections:", td.config.sections())
+   assert td.config.sections() is not None
+   sections = ['Reporter*:*Text*File']
+   print("--->to skip:", sections)
+   expsections = td.expandWildCards(sections)
+   assert 'Reporter:TextFile' in expsections
+   print("--->expanded:", expsections) 
+


### PR DESCRIPTION
- removed --no-reported
- adds support for simple wildcards with --skip-sections
  wildcards in the form of
    - *text, text* and *text* will work
    - text*text will not becaus I just doing a simple
      substring search
    - this might work also with --sections, but I have
      not tested that
- fixed issue with spliting MTT_ARGS strings into commandline
  arguments, before it was doing a simple <space> split, now
  it looks for ' --'

Signed-off-by: Bill Weide <william.c.weide@intel.com>