### PR TITLE
Doxygen improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ script:
   - $TRAVIS_BUILD_DIR/pyclient/pymtt.py --verbose $TRAVIS_BUILD_DIR/tests/bat/default_check_profile.ini
 
 before_deploy:
+  python: 2.7
   - cd docs && doxygen Doxyfile && cd ..
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ script:
   - $TRAVIS_BUILD_DIR/pyclient/pymtt.py --verbose $TRAVIS_BUILD_DIR/tests/bat/default_check_profile.ini
 
 before_deploy:
-  python: 2.7
   - cd docs && doxygen Doxyfile && cd ..
 
 deploy:

--- a/condaEnv.yml
+++ b/condaEnv.yml
@@ -22,6 +22,7 @@ dependencies:
   - wheel=0.31.1
   - pip:
     - doxypy==0.4.1
+    - doxypypy
     - junit-xml==1.8
     - python-hostlist==1.18
     - stevedore==1.29.0

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -281,7 +281,8 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      = ini=Python
+EXTENSION_MAPPING      = 
+
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -498,7 +499,7 @@ INTERNAL_DOCS          = NO
 # and Mac users are advised to set this option to NO.
 # The default value is: system dependent.
 
-CASE_SENSE_NAMES       = YES
+CASE_SENSE_NAMES       = NO
 
 # If the HIDE_SCOPE_NAMES tag is set to NO then doxygen will show members with
 # their full class and namespace scopes in the documentation. If set to YES, the
@@ -758,7 +759,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../pyclient ../pylib ../samples
+INPUT                  = ../pyclient ../pylib 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -778,7 +779,7 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          = *.c *.py *.ini
+FILE_PATTERNS          = *.c *.py 
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -872,7 +873,7 @@ INPUT_FILTER           = "doxypypy"
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        =
+FILTER_PATTERNS        = *.py=py_filter
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for

--- a/docs/py_filter
+++ b/docs/py_filter
@@ -1,0 +1,2 @@
+#!/bin/bash
+doxypypy -a -c $1

--- a/docs/py_filter.bat
+++ b/docs/py_filter.bat
@@ -1,0 +1,1 @@
+doxypypy -a -c %1

--- a/pyenv.txt
+++ b/pyenv.txt
@@ -1,6 +1,7 @@
 Django==1.8.5
 django-enumfield==1.2.1
 doxypy==0.4.1
+doxypypy
 pbr==1.8.1
 psycopg2==2.7.3
 requests==2.9.1


### PR DESCRIPTION
Used https://github.com/Feneric/doxypypy instructions to add a
filter pattern to the Doxygen file. Removed .ini files as part of
documentation because they were causing errors. Updated the environment
files to include doxypypy (Tried adding it to .travis.yml but got
package not found error). Made sure travis was using python 2.7 when
doing the doxygen build.

[Ticket: X]

Signed-off-by: Deb Rezanka <rezanka@lanl.gov>