### PR TITLE
Fixes #798 moved fh var from global to instance

### DIFF
--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -35,7 +35,6 @@ class TextFile(ReporterMTTStage):
         self.options['detail_header'] = (None, "Header to be put at top of detail report")
         self.options['detail_footer'] = (None, "Footer to be placed at bottome of detail report")
         self.options['textwrap'] = ("80", "Max line length before wrapping")
-        self.fh = sys.stdout
 
     def activate(self):
         # get the automatic procedure from IPlugin
@@ -63,6 +62,7 @@ class TextFile(ReporterMTTStage):
                 print("\t"*(tabs),"   ",l, file=self.fh)
 
     def execute(self, log, keyvals, testDef):
+        self.fh = sys.stdout
         testDef.logger.verbose_print("TextFile Reporter")
         num_secs_pass = 0
         # pickup the options


### PR DESCRIPTION
fh (file handle) variable is defined in the __init__ method and as such
only one variable is createdi no matter how many instances of TextFile
are created.

Multiple calls to the TextFile plugin will set this variable to either
stdout or an open file handle, the latter one replacing the previous.

Moved the variable defintion into the execute method, this will allow for
one fh variable to be created per instance of TextFile.

Signed-off-by: Bill Weide <william.c.weide@intel.com>