### PR TITLE
Prevent corner case error with --no-shell

### DIFF
--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -440,7 +440,10 @@ class SLURM(LauncherMTTTool):
                 return
 
         # Add support for srun in --no-shell allocation
-        if self.allocated and (cmds['command'] == 'srun') and ('--job-name' in cmds['allocate_cmd']) and ('--no-shell' in cmds['allocate_cmd']):
+        if self.allocated and (cmds['command'] == 'srun') and \
+            ('--job-name' in cmds['allocate_cmd']) and \
+            ('--no-shell' in cmds['allocate_cmd']) and \
+            ('--jobid=' not in ' '.join(cmdargs)):
             parse_allocate_cmd = cmds['allocate_cmd'].split()
             for word in parse_allocate_cmd:
                 word = word.strip()


### PR DESCRIPTION
SLURM.py in 'Add support for srun in --no-shell allocation' added to
boolean ' and '--jobid-' not in ' '.join(cmdargs):' to avoid a possible
corner case issue.

Fixes #800

Signed-off-by: Deb Rezanka <rezanka@lanl.gov>