### PR TITLE
Revert before autotools commit that broke Autotools.py

### DIFF
--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -280,10 +280,6 @@ class Autotools(BuildMTTTool):
             log['status'] = 0
             return
 
-        # Clean up middlware build directory before building
-        if os.path.exists(pfx):
-            shutil.rmtree(pfx)
-
         # save the current directory so we can return to it
         cwd = os.getcwd()
         # now move to the package location


### PR DESCRIPTION
https://github.com/open-mpi/mtt/issues/816

The previous commit  https://github.com/open-mpi/mtt/commit/f649e180595cf1f66de9156929dff16b3ffcc0d6 broke Autotools, so this is to revert that commit.

The previous commit did not fix what it intended to fix, so reverting the commit.