### PR TITLE
Update Docker README

### DIFF
--- a/server/Dockerfile.cherrypy
+++ b/server/Dockerfile.cherrypy
@@ -18,7 +18,7 @@ RUN rm -f /opt/mtt/server/php/cherrypy/.htaccess
 RUN cd /opt/mtt/server/php/cherrypy && \
     python bin/mtt_server_install.py
 RUN perl -pi -e "s/AuthUserFile \/path\/to\/.htpassword/AuthUserFile \/home\/test\/.htpassword/g" /opt/mtt/server/php/cherrypy/.htaccess
-RUN perl -pi -e "s/127.0.0.1/172.31.0.3/g" /opt/mtt/server/php/cherrypy/bin/mtt_server.cfg
+RUN perl -pi -e "s/127.0.0.1/0.0.0.0/g" /opt/mtt/server/php/cherrypy/bin/mtt_server.cfg
 RUN perl -pi -e "s/mttv3/mtt/g" /opt/mtt/server/php/cherrypy/bin/mtt_server.cfg
 RUN perl -pi -e "s/USERNAME/postgres/g" /opt/mtt/server/php/cherrypy/bin/mtt_server.cfg
 RUN perl -pi -e "s/PASSWORD/mtt/g" /opt/mtt/server/php/cherrypy/bin/mtt_server.cfg

--- a/server/docker/README.docker.txt
+++ b/server/docker/README.docker.txt
@@ -4,14 +4,26 @@ docker network create -d bridge --subnet 172.31.0.0/24 docker_network
 # Build postgres docker image
 docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t mttdb-postgres -f Dockerfile.postgres .
 # Start the postgres server
-docker run --name mttdb-postgres --network=docker_network --ip=172.31.0.2 -e POSTGRES_PASSWORD=mtt -d mttdb-postgres 
+docker run --name mttdb-postgres --network=docker_network -p 5432:5432 -e POSTGRES_PASSWORD=mtt -d mttdb-postgres 
 # Test container
-PGPASSWORD="mtt" psql -a --host=172.31.0.2 --dbname=mtt --username=postgres
+PGPASSWORD="mtt" psql -a --host=localhost --dbname=mtt --username=postgres
 
+# port forwarding for -p N:N may be different. This uses port forwarding on a local machine to point to the docker container.
+
+defined to use port forwarding on a local machine
 # Build cherrypy docker image
 docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t mttdb-cherrypy -f Dockerfile.cherrypy . 
 # Start the cherrypy server
-docker run -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=localhost,mttdb  --name mttdb-cherrypy --network=docker_network --ip=172.31.0.3 -dt mttdb-cherrypy /opt/mtt/server/docker/mtt_cherrypy.sh
+docker run -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e 
+no_proxy=localhost,mttdb  -p 9080:9080 --name mttdb-cherrypy --network=docker_network -dt mttdb-cherrypy /opt/mtt/server/docker/mtt_cherrypy.sh
 
 # Test cherrypy RESTful interface
-curl -H "Content-Type: application/json" -X POST -d '{"data" : [ {"bitness": 0, "endian": "test", "vpath_mode": "test", "platform_hardware": "test", "platform_type": "test", "os_name": "test", "os_version": "test", "compiler_name": "test", "compiler_version": "test", "mpi_name": "test", "mpi_version": "test", "configure_arguments": "test", "start_timestamp": "Mon Jan 1 00:00:00 2000", "duration": "0 Seconds", "result_message": "test", "test_result": 0, "exit_value": 0, "merge_stdout_stderr": 0, "result_stderr": "test"} ], "metadata" : {"client_serial": 12345, "hostname": "test.test.com", "local_username": "test", "mtt_client_version": "4.0a1", "phase": "MPI Install", "platform_name": "triton", "trial": 1}}' http://172.31.0.3:9080/submit --user mtt:mttuser
+curl -H "Content-Type: application/json" -X POST -d '{"data" : [ {"bitness": 0, 
+"endian": "test", "vpath_mode": "test", "platform_hardware": "test", 
+"platform_type": "test", "os_name": "test", "os_version": "test", 
+"compiler_name": "test", "compiler_version": "test", "mpi_name": "test", 
+"mpi_version": "test", "configure_arguments": "test", "start_timestamp": "Mon 
+Jan 1 00:00:00 2000", "duration": "0 Seconds", "result_message": "test", 
+"test_result": 0, "exit_value": 0, "merge_stdout_stderr": 0, "result_stderr": 
+"test"} ], "metadata" : {"client_serial": 12345, "hostname": "test.test.com", 
+"local_username": "test", "mtt_client_version": "4.0a1", "phase": "MPI Install", "platform_name": "triton", "trial": 1}}' http://localhost:9080/submit --user mtt:mttuser


### PR DESCRIPTION
This updates the Docker README on setting up a cherrypy server
with a postgres DB. Using the current instructions results
in errors when making server requests. These turn on port
forwarding when running cherrypy and postgres.