### PR TITLE
Revise ExecuteCmd return value and Refactor Launchers

### DIFF
--- a/pylib/Stages/Profile/CheckProfile.py
+++ b/pylib/Stages/Profile/CheckProfile.py
@@ -98,7 +98,7 @@ class CheckProfile(ProfileMTTStage):
                         # ignore the execution time, if collected
                         return
 
-                    pcentAvail = 100 - int(stdout[0].split('%')[0])
+                    pcentAvail = 100 - int(results['stdout'][0].split('%')[0])
                     myLog[key+' '+disk] = [str(pcentAvail) + "% available"]
 
                     testDef.logger.verbose_print("checking: " + disk \

--- a/pylib/Stages/Profile/CheckProfile.py
+++ b/pylib/Stages/Profile/CheckProfile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -88,13 +88,13 @@ class CheckProfile(ProfileMTTStage):
                     pcentNeeded = int(pcent.split('%')[0])
 
                     cmd = self.diskSpaceCmd[2].replace("DISK", disk)
-                    status, stdout, stderr, time = testDef.execmd.execute(cmds,
+                    results = testDef.execmd.execute(cmds,
                         [self.diskSpaceCmd[0], self.diskSpaceCmd[1], cmd], testDef)
 
-                    if 0 != status:
-                        log['status'] = status
-                        log['stdout'] = stdout
-                        log['stderr'] = stderr
+                    if 0 != results['status']:
+                        log['status'] = results['status']
+                        log['stdout'] = results['stdout']
+                        log['stderr'] = results['stderr']
                         # ignore the execution time, if collected
                         return
 
@@ -125,18 +125,18 @@ class CheckProfile(ProfileMTTStage):
                     if kind == 'used':
                         cmd = self.memoryUsedCmd[2]
 
-                    status, stdout, stderr, time = testDef.execmd.execute(cmds,
+                    results = testDef.execmd.execute(cmds,
                         [self.diskSpaceCmd[0], self.diskSpaceCmd[1], cmd], testDef)
 
-                    if 0 != status:
-                        log['status'] = status
-                        log['stdout'] = stdout
-                        log['stderr'] = stderr
+                    if 0 != results['status']:
+                        log['status'] = results['status']
+                        log['stdout'] = results['stdout']
+                        log['stderr'] = results['stderr']
                         # ignore the execution time, if collected
                         return
 
-                    gigsAvail = float(stdout[0].split('G')[0])
-                    myLog['memory '+kind] = stdout
+                    gigsAvail = float(results['stdout'][0].split('G')[0])
+                    myLog['memory '+kind] = results['stdout']
 
                     testDef.logger.verbose_print("checking: " + kind \
                         + " memory: " + str(gigsAvail) + "G is " + op \

--- a/pylib/Stages/Profile/DefaultProfile.py
+++ b/pylib/Stages/Profile/DefaultProfile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -68,14 +68,14 @@ class DefaultProfile(ProfileMTTStage):
         opts = self.options.keys()
         for key in keys:
             if cmds[key] and key in opts:
-                status, stdout, stderr, time = testDef.execmd.execute(cmds, self.options[key][2], testDef)
-                if 0 != status:
-                    log['status'] = status
-                    log['stdout'] = stdout
-                    log['stderr'] = stderr
+                results = testDef.execmd.execute(cmds, self.options[key][2], testDef)
+                if 0 != results['status']:
+                    log['status'] = results['status']
+                    log['stdout'] = results['stdout']
+                    log['stderr'] = results['stderr']
                     # ignore the execution time, if collected
                     return
-                myLog[key] = stdout
+                myLog[key] = results['stdout']
         # add our log to the system log
         log['profile'] = myLog
         log['status'] = 0

--- a/pylib/Stages/Provisioning/WWulf3.py
+++ b/pylib/Stages/Provisioning/WWulf3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -76,13 +76,13 @@ class WWulf3(ProvisionMTTStage):
         self.allocated = False
         if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None:
             allocate_cmdargs = shlex.split(cmds['allocate_cmd'])
-            status,stdout,stderr,time = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
-            if 0 != status:
-                log['status'] = status
+            results = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
+            if 0 != results['status']:
+                log['status'] = results['status']
                 if log['stderr']:
-                    log['stderr'].extend(stderr)
+                    log['stderr'].extend(results['stderr'])
                 else:
-                    log['stderr'] = stderr
+                    log['stderr'] = results['stderr']
                 return False
             self.allocated = True
         return True
@@ -90,13 +90,13 @@ class WWulf3(ProvisionMTTStage):
     def deallocate(self, log, cmds, testDef):
         if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated == True:
             deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
-            status,stdout,stderr,time = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
-            if 0 != status:
-                log['status'] = status
+            results = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
+            if 0 != results['status']:
+                log['status'] = results['status']
                 if log['stderr']:
-                    log['stderr'].extend(stderr)
+                    log['stderr'].extend(results['stderr'])
                 else:
-                    log['stderr'] = stderr
+                    log['stderr'] = results['stderr']
                 return False
             self.allocated = False
         return True
@@ -159,16 +159,16 @@ class WWulf3(ProvisionMTTStage):
         wwcmd = ["wwsh", "node", "list"]
         if cmds['sudo']:
             wwcmd.insert(0, "sudo")
-        status,stdout,stderr,_ = testDef.execmd.execute(cmds, wwcmd, testDef)
-        if 0 != status or stdout is None:
-            log['status'] = status
+        results = testDef.execmd.execute(cmds, wwcmd, testDef)
+        if 0 != results['status'] or results['stdout'] is None:
+            log['status'] = results['status']
             log['stderr'] = "Node list was not obtained"
             return
         # skip first two lines as they are headers
-        del stdout[0:2]
+        del results['stdout'][0:2]
         # parse each line to collect out the individual nodes
         nodes = []
-        for line in stdout:
+        for line in results['stdout']:
             # node name is at the front, ended by a space
             nodes.append(line[0:line.find(' ')])
         # now check that each target is in the list of nodes - no
@@ -200,10 +200,10 @@ class WWulf3(ProvisionMTTStage):
             if cmds['bootstrap']:
                wwcmd.append("--bootstrap=" + cmds['bootstrap'])
             # update the provisioning database to the new image
-            status,stdout,stderr,_ = testDef.execmd.execute(cmds, wwcmd, testDef)
-            if 0 != status:
-                log['status'] = status
-                log['stderr'] = stderr
+            results = testDef.execmd.execute(cmds, wwcmd, testDef)
+            if 0 != results['status']:
+                log['status'] = results['status']
+                log['stderr'] = results['stderr']
                 self.deallocate(log, cmds, testDef)
                 return
         # assemble command to power cycle each node. Note that

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -180,7 +180,7 @@ class IUDatabase(ReporterMTTStage):
         for lg in fullLog:
             # Find sections prefixed with 'TestRun'
             if re.match("TestRun", lg['section']):
-                rtn = self._submit_test_run(testDef.logger, lg, metadata, s, url, www_auth)
+                rtn = self._submit_test_run(testDef.logger, lg, metadata, s, url, testDef, www_auth)
 
         log['status'] = 0
         return
@@ -190,7 +190,7 @@ class IUDatabase(ReporterMTTStage):
         z.update(y)
         return z
 
-    def _submit_test_run(self, logger, lg, metadata, s, url, httpauth=None):
+    def _submit_test_run(self, logger, lg, metadata, s, url, testDef, httpauth=None):
         try:
             if self.cmds['debug_screen']:
                 print("----------------- Test Run (%s) " % (lg['section']))

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -95,6 +95,20 @@ class TextFile(ReporterMTTStage):
                             print("\t\t",p,"=",opts[p], file=self.fh)
                 except KeyError:
                     pass
+                try:
+                    if lg['mpi_info'] is not None:
+                        print("\tInfo:", file=self.fh)
+                        try:
+                            print("\t\tName:", lg['mpi_info']['name'], file=self.fh)
+                        except KeyError:
+                            pass
+                        try:
+                            print("\t\tVersion:", lg['mpi_info']['version'], file=self.fh)
+                        except KeyError:
+                            pass
+                except KeyError:
+                    pass
+
                 if 0 != lg['status']:
                     if "stderr" in lg:
                         self._print_stderr_block("stderr", lg['stderr'], tabs=1)

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -138,14 +138,44 @@ class TextFile(ReporterMTTStage):
                 pass
             try:
                 if lg['numTests'] is not None:
-                    print("\tTests:",lg['numTests'],"Pass:",lg['numPass'],"Skip:",lg['numSkip'],"Fail:",lg['numFail'], file=self.fh)
+                    try:
+                        npass = str(lg['numPass'])
+                    except:
+                        npass = "N/A"
+                    try:
+                        nskip = str(lg['numSkip'])
+                    except:
+                        nskip = "N/A"
+                    try:
+                        nfail = str(lg['numFail'])
+                    except:
+                        nfail = "N/A"
+                    try:
+                        ntime = str(lg['numTimed'])
+                    except:
+                        ntime = "N/A"
+
+                    print("\tTests:",lg['numTests'],"Pass:",npass,"Skip:",nskip,"Fail:",nfail,"TimedOut:",ntime, file=self.fh)
             except KeyError:
                 pass
             try:
                 if lg['testresults'] is not None:
                     for test in lg['testresults']:
                         tname = os.path.basename(test['test'])
-                        print("\t\t",tname,"  Status:",test['status'], file=self.fh)
+                        try:
+                            if test['result'] == testDef.MTT_TEST_PASSED:
+                                st = "PASSED"
+                            elif test['result'] == testDef.MTT_TEST_FAILED:
+                                st = "FAILED"
+                            elif test['result'] == testDef.MTT_TEST_TIMED_OUT:
+                                st = "TIMED OUT"
+                            elif test['result'] == testDef.MTT_TEST_SKIPPED:
+                                st = "SKIPPED"
+                            else:
+                                st = "UNKNOWN"
+                        except:
+                            st = "NOT GIVEN"
+                        print("\t\t",tname,"  Status:",test['status'], "Category:",st, file=self.fh)
                         if 0 != test['status']:
                             if "stderr" in test:
                                 self._print_stderr_block("stderr", test['stderr'], tabs=3)

--- a/pylib/Stages/Reporter/TextFile.py
+++ b/pylib/Stages/Reporter/TextFile.py
@@ -111,10 +111,10 @@ class TextFile(ReporterMTTStage):
                 pass
             try:
                 if lg['compiler'] is not None:
-                    print("Compiler:", file=self.fh)
+                    print("\tCompiler:", file=self.fh)
                     comp = lg['compiler']
-                    print("\t",comp['family'], file=self.fh)
-                    print("\t",comp['version'], file=self.fh)
+                    print("\t\t",comp['family'], file=self.fh)
+                    print("\t\t",comp['version'], file=self.fh)
             except KeyError:
                 pass
             try:
@@ -155,7 +155,7 @@ class TextFile(ReporterMTTStage):
                     except:
                         ntime = "N/A"
 
-                    print("\tTests:",lg['numTests'],"Pass:",npass,"Skip:",nskip,"Fail:",nfail,"TimedOut:",ntime, file=self.fh)
+                    print("\n\tTests:",lg['numTests'],"Pass:",npass,"Skip:",nskip,"Fail:",nfail,"TimedOut:",ntime,"\n", file=self.fh)
             except KeyError:
                 pass
             try:

--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -269,19 +269,22 @@ class PMIxUnit(TestRunMTTStage):
                 cmdargs.append(s)
             testLog['cmd'] = " ".join(cmdargs)
 
-            status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
+            results = testDef.execmd.execute(cmds, cmdargs, testDef)
 
-            if 0 == status:
+            if 0 == results['status']:
                 numPass = numPass + 1
             else:
                 numFail = numFail + 1
                 if 0 == finalStatus:
                     finalStatus = status
                     finalError = stderr
-            testLog['status'] = status
-            testLog['stdout'] = stdout
-            testLog['stderr'] = stderr
-            testLog['time'] = time
+            testLog['status'] = results['status']
+            testLog['stdout'] = results['stdout']
+            testLog['stderr'] = results['stderr']
+            try:
+                testLog['time'] = results['elapsed_secs']
+            except:
+                pass
             log['testresults'].append(testLog)
             numTests = numTests + 1
 

--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -273,8 +273,10 @@ class PMIxUnit(TestRunMTTStage):
 
             if 0 == results['status']:
                 numPass = numPass + 1
+                testLog['result'] = testDef.MTT_TEST_PASSED
             else:
                 numFail = numFail + 1
+                testLog['result'] = testDef.MTT_TEST_FAILED
                 if 0 == finalStatus:
                     finalStatus = status
                     finalError = stderr

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,6 +27,19 @@ from threading import Semaphore
 from pathlib import Path
 
 is_py2 = sys.version[0] == '2'
+
+# define a few global "constant" names that can be used
+# across plugins - the following categories must match
+# their equivalent values in the server. See
+# https://github.com/open-mpi/mtt-legacy/blob/master/lib/MTT/Values.pm#L43-L57
+# for the list
+
+MTT_TEST_FAILED             =   0
+MTT_TEST_PASSED             =   1
+MTT_TEST_SKIPPED            =   2
+MTT_TEST_TIMED_OUT          =   3
+MTT_TEST_TIMED_OUT_OR_FAIL  =   4
+
 
 # The Test Definition class is mostly a storage construct
 # to make it easier when passing values across stages and
@@ -521,7 +534,7 @@ class TestDef(object):
                     self.fill_log_interpolation("%s.%d" % (basestr, i), v)
         else:
             self.fill_log_interpolation(basestr, str(sublog))
- 
+
     def expandWildCards(self, sections):
         expsec = []
         cpsections = list(sections)
@@ -632,7 +645,7 @@ class TestDef(object):
         self.check_for_nondefined_env_variables()
 
         # find all the sections that match the wild card and expand them
-        # this is simple wild carding, ie *text, text*, *text* and * 
+        # this is simple wild carding, ie *text, text*, *text* and *
         # should all work
         if sections is not None:
             sections = self.expandWildCards(sections)

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -28,18 +28,6 @@ from pathlib import Path
 
 is_py2 = sys.version[0] == '2'
 
-# define a few global "constant" names that can be used
-# across plugins - the following categories must match
-# their equivalent values in the server. See
-# https://github.com/open-mpi/mtt-legacy/blob/master/lib/MTT/Values.pm#L43-L57
-# for the list
-
-MTT_TEST_FAILED             =   0
-MTT_TEST_PASSED             =   1
-MTT_TEST_SKIPPED            =   2
-MTT_TEST_TIMED_OUT          =   3
-MTT_TEST_TIMED_OUT_OR_FAIL  =   4
-
 
 # The Test Definition class is mostly a storage construct
 # to make it easier when passing values across stages and
@@ -89,6 +77,17 @@ class TestDef(object):
         self.log = {}
         self.watchdog = None
         self.plugin_trans_sem = Semaphore()
+        # define a few global "constant" names that can be used
+        # across plugins - the following categories must match
+        # their equivalent values in the server. See
+        # https://github.com/open-mpi/mtt-legacy/blob/master/lib/MTT/Values.pm#L43-L57
+        # for the list
+        self.MTT_TEST_FAILED             =   0
+        self.MTT_TEST_PASSED             =   1
+        self.MTT_TEST_SKIPPED            =   2
+        self.MTT_TEST_TIMED_OUT          =   3
+        self.MTT_TEST_TIMED_OUT_OR_FAIL  =   4
+
 
     def setOptions(self, args):
         self.options = vars(args)

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -289,11 +289,11 @@ class Autotools(BuildMTTTool):
                 args = cmds['autogen_cmd'].split()
                 for arg in args:
                     agargs.append(arg.strip())
-                status, stdout, stderr, _ = testDef.execmd.execute(cmds, agargs, testDef)
-                if 0 != status:
-                    log['status'] = status
-                    log['stdout'] = stdout
-                    log['stderr'] = stderr
+                results = testDef.execmd.execute(cmds, agargs, testDef)
+                if 0 != results['status']:
+                    log['status'] = results['status']
+                    log['stdout'] = results['stdout']
+                    log['stderr'] = results['stderr']
 
                     # Revert any requested environment module settings
                     status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -376,11 +376,11 @@ class Autotools(BuildMTTTool):
                 cfgargs.append(d)
 
             # execute the configure cmd
-            status, stdout, stderr, _ = testDef.execmd.execute(cmds, cfgargs, testDef)
-            if 0 != status:
-                log['status'] = status
-                log['stdout'] = stdout
-                log['stderr'] = stderr
+            results = testDef.execmd.execute(cmds, cfgargs, testDef)
+            if 0 != results['status']:
+                log['status'] = results['status']
+                log['stdout'] = results['stdout']
+                log['stderr'] = results['stderr']
 
                 # Revert any requested environment module settings
                 status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -427,11 +427,11 @@ class Autotools(BuildMTTTool):
             pass
         # step thru the process, starting with "clean"
         bldargs.append("clean")
-        status, stdout, stderr, _ = testDef.execmd.execute(cmds, bldargs, testDef)
-        if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
+        results = testDef.execmd.execute(cmds, bldargs, testDef)
+        if 0 != results['status']:
+            log['status'] = results['status']
+            log['stdout'] = results['stdout']
+            log['stderr'] = results['stderr']
 
             # Revert any requested environment module settings
             status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -459,11 +459,11 @@ class Autotools(BuildMTTTool):
         # now execute "make all"
         bldargs = bldargs[0:-1]
         bldargs.append("all")
-        status, stdout, stderr, _ = testDef.execmd.execute(cmds, bldargs, testDef)
-        if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
+        results = testDef.execmd.execute(cmds, bldargs, testDef)
+        if 0 != results['status']:
+            log['status'] = results['status']
+            log['stdout'] = results['stdout']
+            log['stderr'] = results['stderr']
 
             # Revert any requested environment module settings
             status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -492,12 +492,12 @@ class Autotools(BuildMTTTool):
         if prefix is not None:
             bldargs = bldargs[0:-1]
             bldargs.append("install")
-            status, stdout, stderr, _ = testDef.execmd.execute(cmds, bldargs, testDef)
+            results = testDef.execmd.execute(cmds, bldargs, testDef)
         # this is the end of the operation, so the status is our
         # overall status
-        log['status'] = status
-        log['stdout'] = stdout
-        log['stderr'] = stderr
+        log['status'] = results['status']
+        log['stdout'] = results['stdout']
+        log['stderr'] = results['stderr']
 
         # Revert any requested environment module settings
         status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -100,6 +100,8 @@ class Autotools(BuildMTTTool):
                     log['status'] = 1
                     log['stderr'] = "Parent",cmds['parent'],"log not found"
                     return
+                # record the parent in our log
+                log['parent'] = cmds['parent']
             else:
                 log['status'] = 1
                 log['stderr'] = "Parent log not recorded"

--- a/pylib/Tools/Build/Hostfile.py
+++ b/pylib/Tools/Build/Hostfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -155,13 +155,13 @@ class Hostfile(BuildMTTTool):
         ################################
         # Execute Plugin
         ################################
-        status, stdout, stderr, time = testDef.execmd.execute(cmds, shlex.split(cmds['nodestatus_cmd']), testDef)
-        if status != 0:
+        results = testDef.execmd.execute(cmds, shlex.split(cmds['nodestatus_cmd']), testDef)
+        if results['status'] != 0:
             log['status'] = 1
             log['stderr'] = "Command %s failed: %s" % (cmds['nodestatus_cmd'], " ".join(stderr))
             os.chdir(cwd)
             return
-        stdout_split = [l.split() for l in stdout]
+        stdout_split = [l.split() for l in results['stdout']]
         try:
             nodename_column = int(cmds['nodename_column'])
         except ValueError:
@@ -178,7 +178,7 @@ class Hostfile(BuildMTTTool):
             node_status = {l[nodename_column]: l[nodestatus_column] for l in stdout_split}
         except IndexError:
             log['status'] = 1
-            log['stderr'] = "" 
+            log['stderr'] = ""
             if nodename_column < 0 or nodename_column >= len(stdout_split[0]):
                 log['stderr'] += "nodename_column is out of bounds: %s  " % str(nodename_column)
             if nodestatus_column < 0 or nodestatus_column >= len(stdout_split[0]):

--- a/pylib/Tools/CNC/IPMITool.py
+++ b/pylib/Tools/CNC/IPMITool.py
@@ -56,17 +56,17 @@ class workerThread(threading.Thread):
                         ntries = 0
                         while True:
                             ++ntries
-                            status,stdout,stderr,_ = self.testDef.execmd.execute(None, task['cmd'], self.testDef)
-                            if 0 == status or ntries == task['maxtries']:
+                            results = self.testDef.execmd.execute(None, task['cmd'], self.testDef)
+                            if 0 == results['status'] or ntries == task['maxtries']:
                                 self.testDef.logger.verbose_print("IPMITool: node " + task['target'] + " is back")
                                 break
                         # record the result
                         self.lock.acquire()
-                        if 0 != status and ntries >= task['maxtries']:
+                        if 0 != results['status'] and ntries >= task['maxtries']:
                             msg = "Operation timed out on node " + task['target']
                             self.status.append((-1, ' '.join(task['cmd']), msg))
                         else:
-                            self.status.append((status, stdout, stderr))
+                            self.status.append((results['status'], results['stdout'], results['stderr']))
                         self.lock.release()
                         continue
                 except:
@@ -95,9 +95,9 @@ class workerThread(threading.Thread):
                                 continue
                             # send it off to ipmitool to execute
                             self.testDef.logger.verbose_print("IPMITool: " + ' '.join(task['cmd']))
-                            st,stdout,stderr,_ = self.testDef.execmd.execute(None, task['cmd'], self.testDef)
+                            results = self.testDef.execmd.execute(None, task['cmd'], self.testDef)
                             self.lock.acquire()
-                            self.status.append((st, stdout, stderr))
+                            self.status.append((results['status'], results['stdout'], results['stderr']))
                             try:
                                 if task['target'] is not None:
                                     # add the reset command to the queue

--- a/pylib/Tools/Fetch/FetchRPM.py
+++ b/pylib/Tools/Fetch/FetchRPM.py
@@ -107,8 +107,8 @@ class FetchRPM(FetchMTTTool):
         for t in tmp:
             qcmd.append(t)
         qcmd.append(rpm)
-        status, stdout, stderr, _ = testDef.execmd.execute(None, qcmd, testDef)
-        if 0 == status:
+        results = testDef.execmd.execute(None, qcmd, testDef)
+        if 0 == results['status']:
             log['status'] = 0
             log['stdout'] = "RPM " + rpm + " already exists on system"
             return
@@ -122,17 +122,17 @@ class FetchRPM(FetchMTTTool):
             icmd.append(t)
         icmd.append(rpm)
         testDef.logger.verbose_print("installing package " + rpm)
-        status, stdout, stderr, _ = testDef.execmd.execute(None, icmd, testDef)
-        if 0 != status:
+        results = testDef.execmd.execute(None, icmd, testDef)
+        if 0 != results['status']:
             log['status'] = 1
             log['stderr'] = "install of " + rpm + " FAILED"
             return
 
         # record the result
-        log['status'] = status
-        log['stdout'] = stdout
-        log['stderr'] = stderr
+        log['status'] = results['status']
+        log['stdout'] = results['stdout']
+        log['stderr'] = results['stderr']
 
         # track that we serviced this one
-        self.done[rpm] = status
+        self.done[rpm] = results['status']
         return

--- a/pylib/Tools/Fetch/FetchTarball.py
+++ b/pylib/Tools/Fetch/FetchTarball.py
@@ -116,6 +116,7 @@ class FetchTarball(FetchMTTTool):
 
         # change to the scratch directory
         os.chdir(dst)
+        results = {}
         # see if this software has already been fetched
         if os.path.exists(tarball):
             # was it expanded?
@@ -123,24 +124,24 @@ class FetchTarball(FetchMTTTool):
                 # if they want us to leave it as-is, then we are done
                 try:
                     if cmds['asis']:
-                        status = 0
-                        stdout = None
-                        stderr = None
+                        results['status'] = 0
+                        results['stdout'] = None
+                        results['stderr'] = None
                 # If not as-is clear directory and download the tarball
                 except KeyError:
                     shutil.rmtree(package)
                     # untar the tarball
                     testDef.logger.verbose_print("untarring tarball " + tarball)
-                    status, stdout, stderr, _ = testDef.execmd.execute(None, ["tar", "-xf", tarball], testDef)
-                    if 0 != status:
+                    results = testDef.execmd.execute(None, ["tar", "-xf", tarball], testDef)
+                    if 0 != results['status']:
                         log['status'] = 1
                         log['stderr'] = "untar of tarball " + tarball + "FAILED"
                         return
             else:
                 # untar the tarball
                 testDef.logger.verbose_print("untarring tarball " + tarball)
-                status, stdout, stderr, _ = testDef.execmd.execute(None, ["tar", "-xf", tarball], testDef)
-                if 0 != status:
+                results = testDef.execmd.execute(None, ["tar", "-xf", tarball], testDef)
+                if 0 != results['status']:
                     log['status'] = 1
                     log['stderr'] = "untar of tarball " + tarball + "FAILED"
                     return
@@ -151,30 +152,30 @@ class FetchTarball(FetchMTTTool):
             for p in fetchcmd:
                 excmd.append(p)
             excmd.append(url)
-            status, stdout, stderr, _ = testDef.execmd.execute(None, excmd, testDef)
-            if 0 != status:
+            results = testDef.execmd.execute(None, excmd, testDef)
+            if 0 != results['status']:
                 log['status'] = 1
                 log['stderr'] = "download for tarball " + tarball + " url: " + url + "FAILED"
                 return
             # untar the tarball
             testDef.logger.verbose_print("untarring tarball " + tarball)
-            status, stdout, stderr, _ = testDef.execmd.execute(None, ["tar", "-zxf", tarball], testDef)
-            if 0 != status:
+            results = testDef.execmd.execute(None, ["tar", "-zxf", tarball], testDef)
+            if 0 != results['status']:
                 log['status'] = 1
                 log['stderr'] = "untar of tarball " + tarball_name + "FAILED"
                 return
         # move into the resulting directory
         os.chdir(package)
         # record the result
-        log['status'] = status
-        log['stdout'] = stdout
-        log['stderr'] = stderr
+        log['status'] = results['status']
+        log['stdout'] = results['stdout']
+        log['stderr'] = results['stderr']
         testDef.logger.verbose_print("setting location to " + package)
 
         # log our absolute location so others can find it
         log['location'] = os.getcwd()
         # track that we serviced this one
-        self.done[tarball] = (status, log['location'])
+        self.done[tarball] = (results['status'], log['location'])
 
         # change back to the original directory
         os.chdir(cwd)

--- a/pylib/Tools/Fetch/Git.py
+++ b/pylib/Tools/Fetch/Git.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -211,6 +211,7 @@ class Git(FetchMTTTool):
         # change to the scratch directory
         os.chdir(dst)
         # see if this software has already been cloned
+        results = {}
         if os.path.exists(repo):
             if not os.path.isdir(repo):
                 log['status'] = 1
@@ -223,24 +224,24 @@ class Git(FetchMTTTool):
             # if they want us to leave it as-is, then we are done
             try:
                 if cmds['asis']:
-                    status = 0
-                    stdout = None
-                    stderr = None
+                    results['status'] = 0
+                    results['stdout'] = None
+                    results['stderr'] = None
             except KeyError:
                 # since it already exists, let's just update it
-                status, stdout, stderr, _ = testDef.execmd.execute(cmds, ["git", "pull"], testDef)
+                results = testDef.execmd.execute(cmds, ["git", "pull"], testDef)
         else:
             # clone it
             if branch is not None:
-                status, stdout, stderr, _ = testDef.execmd.execute(cmds, ["git", "clone", "-b", branch, url], testDef)
+                results = testDef.execmd.execute(cmds, ["git", "clone", "-b", branch, url], testDef)
             else:
-                status, stdout, stderr, _ = testDef.execmd.execute(cmds, ["git", "clone", url], testDef)
+                results = testDef.execmd.execute(cmds, ["git", "clone", url], testDef)
             # move into it
             os.chdir(repo)
         # record the result
-        log['status'] = status
-        log['stdout'] = stdout
-        log['stderr'] = stderr
+        log['status'] = results['status']
+        log['stdout'] = results['stdout']
+        log['stderr'] = results['stderr']
 
         # log our absolute location so others can find it
         log['location'] = os.getcwd()

--- a/pylib/Tools/Fetch/OMPI_Snapshot.py
+++ b/pylib/Tools/Fetch/OMPI_Snapshot.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -162,6 +162,7 @@ class OMPI_Snapshot(FetchMTTTool):
         # change to the scratch directory
         os.chdir(dst)
         # see if this software has already been cloned
+        results = {}
         if os.path.exists(tarball_base_name):
             if not os.path.isdir(tarball_base_name):
                 log['status'] = 1
@@ -172,47 +173,47 @@ class OMPI_Snapshot(FetchMTTTool):
             # if they want us to leave it as-is, then we are done
             try:
                 if cmds['asis']:
-                    status = 0
-                    stdout = None
-                    stderr = None
+                    results['status'] = 0
+                    results['stdout'] = None
+                    results['stderr'] = None
             # If not as-is clear directory and download the tarball
             except KeyError:
                 shutil.rmtree(tarball_base_name)
                 # download the tarball - TODO probably need to do a try on these
                 testDef.logger.verbose_print("downloading tarball " + tarball_name + "url: " + download_url)
-                status, stdout, stderr, _ = testDef.execmd.execute(None, ["curl", "-o", tarball_name, download_url], testDef)
-                if 0 != status:
+                results = testDef.execmd.execute(None, ["curl", "-o", tarball_name, download_url], testDef)
+                if 0 != results['status']:
                     log['status'] = 1
                     log['stderr'] = "download for tarball " + tarball_name + "url: " + download_url + "FAILED"
                     return
                 # untar the tarball
                 testDef.logger.verbose_print("untarring tarball " + tarball_name)
-                status, stdout, stderr, _ = testDef.execmd.execute(None, ["tar", "-zxf", tarball_name], testDef)
-                if 0 != status:
+                results = testDef.execmd.execute(None, ["tar", "-zxf", tarball_name], testDef)
+                if 0 != results['status']:
                     log['status'] = 1
                     log['stderr'] = "untar of tarball " + tarball_name + "FAILED"
                     return
         else:
             # download the tarball - TODO probably need to do a try on these
             testDef.logger.verbose_print("downloading tarball " + tarball_name + "url: " + download_url)
-            status, stdout, stderr, _ = testDef.execmd.execute(None, ["curl", "-o", tarball_name, download_url], testDef)
-            if 0 != status:
+            results = testDef.execmd.execute(None, ["curl", "-o", tarball_name, download_url], testDef)
+            if 0 != results['status']:
                 log['status'] = 1
                 log['stderr'] = "download for tarball " + tarball_name + "url: " + download_url + "FAILED"
                 return
             # untar the tarball
             testDef.logger.verbose_print("untarring tarball " + tarball_name)
-            status, stdout, stderr, _ = testDef.execmd.execute(None, ["tar", "-zxf", tarball_name], testDef)
-            if 0 != status:
+            results = testDef.execmd.execute(None, ["tar", "-zxf", tarball_name], testDef)
+            if 0 != results['status']:
                 log['status'] = 1
                 log['stderr'] = "untar of tarball " + tarball_name + "FAILED"
                 return
         # move into the resulting directory
         os.chdir(tarball_base_name)
         # record the result
-        log['status'] = status
-        log['stdout'] = stdout
-        log['stderr'] = stderr
+        log['status'] = results['status']
+        log['stdout'] = results['stdout']
+        log['stderr'] = results['stderr']
         log['mpi_info'] = {'name' : cmds['mpi_name'], 'version' : snapshot_req.text.strip()}
         testDef.logger.verbose_print("setting mpi_info to " + str(log.get('mpi_info')))
 

--- a/pylib/Tools/Fetch/Pip.py
+++ b/pylib/Tools/Fetch/Pip.py
@@ -103,12 +103,12 @@ class Pip(FetchMTTTool):
         qcmd.append("pip")
         qcmd.append("show")
         qcmd.append(pkg)
-        status, stdout, stderr, _ = testDef.execmd.execute(None, qcmd, testDef)
-        if 0 == status:
+        results = testDef.execmd.execute(None, qcmd, testDef)
+        if 0 == results['status']:
             log['status'] = 0
             log['stdout'] = "PKG " + pkg + " already exists on system"
             # Find the location
-            for t in stdout:
+            for t in results['stdout']:
                 if t.startswith("Location"):
                     log['location'] = t[10:]
                     break
@@ -124,21 +124,21 @@ class Pip(FetchMTTTool):
             icmd.append("--user")
         icmd.append(pkg)
         testDef.logger.verbose_print("installing package " + pkg)
-        status, stdout, stderr, _ = testDef.execmd.execute(None, icmd, testDef)
-        if 0 != status:
+        results = testDef.execmd.execute(None, icmd, testDef)
+        if 0 != results['status']:
             log['status'] = 1
             log['stderr'] = "install of " + pkg + " FAILED"
             return
 
         # record the result
-        log['status'] = status
-        log['stdout'] = stdout
-        log['stderr'] = stderr
+        log['status'] = results['status']
+        log['stdout'] = results['stdout']
+        log['stderr'] = results['stderr']
         # Find where it went
-        status, stdout, stderr, _ = testDef.execmd.execute(None, qcmd, testDef)
-        if 0 == status:
+        results = testDef.execmd.execute(None, qcmd, testDef)
+        if 0 == results['status']:
             # Find the location
-            for t in stdout:
+            for t in results['stdout']:
                 if t.startswith("Location"):
                     log['location'] = t[10:]
                     # Add the location to PYTHONPATH
@@ -147,5 +147,5 @@ class Pip(FetchMTTTool):
                     break
 
         # track that we serviced this one
-        self.done[pkg] = status
+        self.done[pkg] = results['status']
         return

--- a/pylib/Tools/Harasser/Harasser.py
+++ b/pylib/Tools/Harasser/Harasser.py
@@ -85,7 +85,7 @@ class Harasser(HarasserMTTTool):
     def parallel_execute(self, cmds, cmdargs, testDef):
         """This function is passed into multiprocessing as a target
         """
-        status,stdout,stderr,time,_ = testDef.execmd.execute(cmds, cmdargs, testDef)
+        results = testDef.execmd.execute(cmds, cmdargs, testDef)
 
     def start(self, testDef):
         """Harassment is started on the system
@@ -150,10 +150,10 @@ class Harasser(HarasserMTTTool):
         return_info = []
         for process,ops,starttime in process_info:
             cmdargs = ops['stop_script'].split()
-            status,stdout,stderr,time,_ = testDef.execmd.execute({k:v[0] for k,v in self.options.items()}, cmdargs, testDef)
-            return_info.append((status,stdout,stderr,datetime.datetime.now()-starttime))
+            results = testDef.execmd.execute({k:v[0] for k,v in self.options.items()}, cmdargs, testDef)
+            return_info.append((results['status'],results['stdout'],results['stderr'],datetime.datetime.now()-starttime))
 
-        for (process,ops,starttime),(status,stdout,stderr,time) in zip(process_info,return_info):
+        for (process,ops,starttime),(results['status'],results['stdout'],results['stderr'],results['elapsed_secs']) in zip(process_info,return_info):
             if status == 0:
                 if self.options['join_timeout'][0] is None:
                     process.join()

--- a/pylib/Tools/Harasser/Harasser.py
+++ b/pylib/Tools/Harasser/Harasser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -85,7 +85,7 @@ class Harasser(HarasserMTTTool):
     def parallel_execute(self, cmds, cmdargs, testDef):
         """This function is passed into multiprocessing as a target
         """
-        status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
+        status,stdout,stderr,time,_ = testDef.execmd.execute(cmds, cmdargs, testDef)
 
     def start(self, testDef):
         """Harassment is started on the system
@@ -120,7 +120,7 @@ class Harasser(HarasserMTTTool):
                             target=self.parallel_execute, \
                             args=({k:v[0] for k,v in self.options.items()},cmdargs,testDef))
             process.start()
-            
+
             self.running_harassers[self.execution_counter] = (process, ops, datetime.datetime.now())
             exec_ids.append(self.execution_counter)
             self.execution_counter += 1
@@ -150,7 +150,7 @@ class Harasser(HarasserMTTTool):
         return_info = []
         for process,ops,starttime in process_info:
             cmdargs = ops['stop_script'].split()
-            status,stdout,stderr,time = testDef.execmd.execute({k:v[0] for k,v in self.options.items()}, cmdargs, testDef)
+            status,stdout,stderr,time,_ = testDef.execmd.execute({k:v[0] for k,v in self.options.items()}, cmdargs, testDef)
             return_info.append((status,stdout,stderr,datetime.datetime.now()-starttime))
 
         for (process,ops,starttime),(status,stdout,stderr,time) in zip(process_info,return_info):

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -80,10 +80,9 @@ class ALPS(LauncherMTTTool):
 
     def deactivate(self):
         IPlugin.deactivate(self)
-        if self.allocated and self.testDef and self.cmds:
+        if self.testDef and self.cmds:
             deallocate_cmdargs = shlex.split(self.cmds['deallocate_cmd'])
-            _status,_stdout,_stderr,_time = self.testDef.execmd.execute(self.cmds, deallocate_cmdargs, self.testDef)
-            self.allocated = False
+            self.deallocateCluster(None, self.cmds, self.testDef)
 
 
     def print_name(self):
@@ -96,11 +95,7 @@ class ALPS(LauncherMTTTool):
         return
 
     def execute(self, log, keyvals, testDef):
-
         self.testDef = testDef
-
-        midpath = False
-
         testDef.logger.verbose_print("ALPS Launcher")
 
         # parse any provided options - these will override the defaults
@@ -110,189 +105,35 @@ class ALPS(LauncherMTTTool):
 
         # check the log for the title so we can
         # see if this is setting our default behavior
-        try:
-            if log['section'] is not None:
-                if "Default" in log['section']:
-                    # this section contains default settings
-                    # for this launcher
-                    myopts = {}
-                    testDef.parseOptions(log, self.options, keyvals, myopts)
-                    # transfer the findings into our local storage
-                    keys = list(self.options.keys())
-                    optkeys = list(myopts.keys())
-                    for optkey in optkeys:
-                        for key in keys:
-                            if key == optkey:
-                                self.options[key] = (myopts[optkey],self.options[key][1])
-
-                    # we captured the default settings, so we can
-                    # now return with success
-                    log['status'] = 0
-                    return
-        except KeyError:
-            # error - the section should have been there
-            log['status'] = 1
-            log['stderr'] = "Section not specified"
+        status = self.updateDefaults(log, self.options, keyvals)
+        if status != 0:
+            # indicates there is nothing more for us to do - status
+            # et al is already in the log
             return
-        # must be executing a test of some kind - the install stage
-        # must be specified so we can find the tests to be run
-        try:
-            parent = keyvals['parent']
-            if parent is not None:
-                # get the log entry as it contains the location
-                # of the built tests
-                bldlog = testDef.logger.getLog(parent)
-                try:
-                    location = bldlog['location']
-                except KeyError:
-                    # if it wasn't recorded, then there is nothing
-                    # we can do
-                    log['status'] = 1
-                    log['stderr'] = "Location of built tests was not provided"
-                    return
-                status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], bldlog, cmds, testDef)
-                if 0 != status:
-                    log['status'] = status
-                    log['stdout'] = stdout
-                    log['stderr'] = stderr
-                    return
 
-                # get the log of any middleware so we can get its location
-                try:
-                    midlog = testDef.logger.getLog(bldlog['middleware'])
-                    if midlog is not None:
-                        # get the location of the middleware
-                        try:
-                            if midlog['location'] is not None:
-                                # prepend that location to our paths
-                                try:
-                                    oldbinpath = os.environ['PATH']
-                                    pieces = oldbinpath.split(':')
-                                except KeyError:
-                                    oldbinpath = ""
-                                    pieces = []
-                                bindir = os.path.join(midlog['location'], "bin")
-                                pieces.insert(0, bindir)
-                                newpath = ":".join(pieces)
-                                os.environ['PATH'] = newpath
-                                # prepend the loadable lib path
-                                try:
-                                    oldldlibpath = os.environ['LD_LIBRARY_PATH']
-                                    pieces = oldldlibpath.split(':')
-                                except KeyError:
-                                    oldldlibpath = ""
-                                    pieces = []
-                                bindir = os.path.join(midlog['location'], "lib")
-                                pieces.insert(0, bindir)
-                                newpath = ":".join(pieces)
-                                os.environ['LD_LIBRARY_PATH'] = newpath
-    
-                                # mark that this was done
-                                midpath = True
-                        except KeyError:
-                            # if it was already installed, then no location would be provided
-                            pass
-                        # check for modules required by the middleware
-                        status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], midlog, cmds, testDef)
-                        if 0 != status:
-                            log['status'] = status
-                            log['stdout'] = stdout
-                            log['stderr'] = stderr
-                            return
-                except KeyError:
-                    pass
-        except KeyError:
+        # now let's setup the PATH and LD_LIBRARY_PATH as reqd
+        status = self.setupPaths(log, keyvals, cmds, testDef)
+        if status != 0:
+            # something went wrong - error is in the log
+            return
+
+        # collect the tests to be considered
+        tests = []
+        self.collectTests(log, cmds, tests)
+        # check that we found something
+        if not tests:
             log['status'] = 1
-            log['stderr'] = "Parent test build stage was not provided"
+            log['stderr'] = "No tests found"
+            self.resetPaths(log, testDef)
             return
 
         # Check if command is correct
         if cmds['command'] != "aprun":
             log['status'] = 1
             log['stderr'] = "Command for ALPS plugin must be aprun. It is currently '%s'" % (cmds['command'] if cmds['command'] is not None else "None")
+            self.resetPaths(log, testDef)
             return
 
-        # Apply any requested environment module settings
-        status,stdout,stderr = testDef.modcmd.applyModules(log['section'], cmds, testDef)
-        if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
-            return
-
-        # now ready to execute the test - we are pointed at the middleware
-        # and have obtained the list of any modules associated with it. We need
-        # to change to the test location and begin executing, first saving
-        # our current location so we can return when done
-        cwd = os.getcwd()
-        os.chdir(location)
-        # did they give us a list of specific directories where the desired
-        # tests to be executed reside?
-        tests = []
-        if cmds['test_list'] is None:
-            try:
-                if cmds['test_dir'] is not None:
-                    # pick up the executables from the specified directories
-                    dirs = cmds['test_dir'].split()
-                    for dr in dirs:
-                        dr = dr.strip()
-                        # remove any commas and quotes
-                        dr = dr.replace('\"','')
-                        dr = dr.replace(',','')
-                        for dirName, subdirList, fileList in os.walk(dr):
-                            for fname in fileList:
-                                # see if this is an executable
-                                filename = os.path.abspath(os.path.join(dirName,fname))
-                                if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                                    # add this file to our list of tests to execute
-                                    tests.append(filename)
-                else:
-                    # get the list of executables from this directory and any
-                    # subdirectories beneath it
-                    for dirName, subdirList, fileList in os.walk("."):
-                        for fname in fileList:
-                            # see if this is an executable
-                            filename = os.path.abspath(os.path.join(dirName,fname))
-                            if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                                # add this file to our list of tests to execute
-                                tests.append(filename)
-            except KeyError:
-                # get the list of executables from this directory and any
-                # subdirectories beneath it
-                for dirName, subdirList, fileList in os.walk("."):
-                    for fname in fileList:
-                        # see if this is an executable
-                        filename = os.path.abspath(os.path.join(dirName,fname))
-                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                            # add this file to our list of tests to execute
-                            tests.append(filename)
-        # If list of tests is provided, use list rather than grabbing all tests
-        else:
-            if cmds['test_dir'] is not None:
-                dirs = cmds['test_dir'].split()
-            else:
-                dirs = ['.']
-            for dr in dirs:
-                dr = dr.strip()
-                dr = dr.replace('\"','')
-                dr = dr.replace(',','')
-                for dirName, subdirList, fileList in os.walk(dr):
-                    for fname in cmds['test_list'].split(","):
-                        fname = fname.strip()
-                        if fname not in fileList:
-                            continue
-                        filename = os.path.abspath(os.path.join(dirName,fname))
-                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                            tests.append(filename)
-
-        # check that we found something
-        if not tests:
-            log['status'] = 1
-            log['stderr'] = "No tests found"
-            os.chdir(cwd)
-            return
-        # get the "skip" exit status
-        skipStatus = int(cmds['skipped'])
         # assemble the command
         cmdargs = [cmds['command']]
         if cmds['options'] is not None:
@@ -305,129 +146,21 @@ class ALPS(LauncherMTTTool):
         if cmds['hostfile'] is not None:
             cmdargs.append("--node-list-file")
             cmdargs.append(cmds['hostfile'])
-        # cycle thru the list of tests and execute each of them
-        log['testresults'] = []
-        finalStatus = 0
-        finalError = ""
-        numTests = 0
-        numPass = 0
-        numSkip = 0
-        numFail = 0
-        if cmds['max_num_tests'] is not None:
-            maxTests = int(cmds['max_num_tests'])
-        else:
-            maxTests = 10000000
-
-        fail_tests = cmds['fail_tests']
-        if fail_tests is not None:
-            fail_tests = [t.strip() for t in fail_tests.split(",")]
-        else:
-            fail_tests = []
-        for i,t in enumerate(fail_tests):
-            for t2 in tests:
-                if t2.split("/")[-1] == t:
-                    fail_tests[i] = t2
-        fail_returncodes = cmds['fail_returncodes']
-        if fail_returncodes is not None:
-            fail_returncodes = [int(t.strip()) for t in fail_returncodes.split(",")]
-
-        if fail_tests is None:
-            expected_returncodes = {test:0 for test in tests}
-        else:
-            if fail_returncodes is None:
-                expected_returncodes = {test:(None if test in fail_tests else 0) for test in tests}
-            else:
-                fail_returncodes = {test:rtncode for test,rtncode in zip(fail_tests,fail_returncodes)}
-                expected_returncodes = {test:(fail_returncodes[test] if test in fail_returncodes else 0) for test in tests}
 
         # Allocate cluster
-        self.allocated = False
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None:
-            self.allocated = True
-            allocate_cmdargs = shlex.split(cmds['allocate_cmd'])
-            _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
-            if 0 != _status:
-                log['status'] = _status
-                log['stderr'] = _stderr
-                os.chdir(cwd)
-                return
+        status = self.allocateCluster(log, cmds, testDef)
+        if 0 != status:
+            self.resetPaths(log, testDef)
+            return
 
-        # For test in tests
-        for test in tests:
-            # Skip tests that are in "skip_tests" ini input
-            if cmds['skip_tests'] is not None and test.split('/')[-1] in [st.strip() for st in cmds['skip_tests'].split()]:
-                numTests += 1
-                numSkip += 1
-                if numTests == maxTests:
-                    break
-                continue
-            testLog = {'test':test}
-            cmdargs.append(test)
-            testLog['cmd'] = " ".join(cmdargs)
-
-            harass_exec_ids = testDef.harasser.start(testDef)
-
-            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
-            if harass_check is not None:
-                testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
-                                + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
-                testLog['time'] = sum([r_info[3] for r_info in harass_check[1]])
-                testLog['status'] = 1
-                finalStatus = 1
-                finalError = testLog['stderr']
-                numFail = numFail + 1
-                testDef.harasser.stop(harass_exec_ids, testDef)
-                continue
-
-            status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
-
-            testDef.harasser.stop(harass_exec_ids, testDef)
-
-            if 0 != status and skipStatus != status and 0 == finalStatus:
-                if expected_returncodes[test] == 0:
-                    finalStatus = status
-                else:
-                    finalStatus = 1
-                finalError = stderr
-            if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
-                numPass = numPass + 1
-            elif skipStatus == status:
-                numSkip = numSkip + 1
-            else:
-                numFail = numFail + 1
-            if expected_returncodes[test] == 0:
-                testLog['status'] = status
-            else:
-                if status == expected_returncodes[test]:
-                    testLog['status'] = 0
-                else:
-                    testLog['status'] = 1
-            testLog['stdout'] = stdout
-            testLog['stderr'] = stderr
-            testLog['time'] = time
-            log['testresults'].append(testLog)
-            cmdargs = cmdargs[:-1]
-            numTests = numTests + 1
-            if numTests == maxTests:
-                break
+        # execute the tests
+        self.runTests(log, cmdargs, cmds, testDef)
 
         # Deallocate cluster
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated:
-            deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
-            _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
-            if 0 != _status:
-                log['status'] = _status
-                log['stderr'] = _stderr
-                os.chdir(cwd)
-                return
-            self.allocated = False
+        self.deallocateCluster(log, cmds, testDef)
 
-        log['status'] = finalStatus
-        log['stderr'] = finalError
-        log['numTests'] = numTests
-        log['numPass'] = numPass
-        log['numSkip'] = numSkip
-        log['numFail'] = numFail
+        # reset our paths and return us to our cwd
+        self.resetPaths(log, testDef)
 
         # handle case where aprun is used instead of mpirun for number of processes (np)
         if 'np' not in cmds or cmds['np'] is None:
@@ -444,18 +177,4 @@ class ALPS(LauncherMTTTool):
         else:
             log['np'] = cmds['np']
 
-        # Revert any requested environment module settings
-        status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
-        if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
-            return
-
-        # if we added middleware to the paths, remove it
-        if midpath:
-            os.environ['PATH'] = oldbinpath
-            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
-
-        os.chdir(cwd)
         return

--- a/pylib/Tools/Launcher/LauncherMTTTool.py
+++ b/pylib/Tools/Launcher/LauncherMTTTool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,9 +18,423 @@ from yapsy.IPlugin import IPlugin
 # @}
 class LauncherMTTTool(IPlugin):
     def __init__(self):
+        self.tests = []
+        self.skip_tests = []
+        self.oldbinpath = ""
+        self.oldldlibpath = ""
+        self.skipStatus = 77
+        self.expected_returncodes = {}
+        self.finalStatus = 0
+        self.finalError = ""
+        self.numTests = 0
+        self.numPass = 0
+        self.numSkip = 0
+        self.numFail = 0
+        self.maxTests = 10000000
         # initialise parent class
         IPlugin.__init__(self)
 
     def print_name(self):
         print("Launcher")
+
+    def updateDefaults(self, log, options, keyvals):
+        # check the log for the title so we can
+        # see if this is setting our default behavior
+        try:
+            if log['section'] is not None:
+                if "Default" in log['section']:
+                    # this section contains default settings
+                    # for this launcher
+                    myopts = {}
+                    testDef.parseOptions(log, options, keyvals, myopts)
+                    # transfer the findings into our local storage
+                    keys = list(options.keys())
+                    optkeys = list(myopts.keys())
+                    for optkey in optkeys:
+                        for key in keys:
+                            if key == optkey:
+                                options[key] = (myopts[optkey], options[key][1])
+
+                    # we captured the default settings, so we can
+                    # now return with success
+                    log['status'] = 0
+                    return 1
+        except KeyError:
+            # error - the section should have been there
+            log['status'] = 1
+            log['stderr'] = "Section not specified"
+            return 1
+        # otherwise, just let them know to continue on
+        return 0
+
+    def setupPaths(self, log, keyvals, cmds, testDef):
+        # the test install stage must be specified so we can find the tests to be run
+        try:
+            parent = keyvals['parent']
+            if parent is not None:
+                # get the log entry as it contains the location
+                # of the built tests
+                bldlog = testDef.logger.getLog(parent)
+                try:
+                    self.location = bldlog['location']
+                except KeyError:
+                    # if it wasn't recorded, then there is nothing
+                    # we can do
+                    log['status'] = 1
+                    log['stderr'] = "Location of built tests was not provided"
+                    return 1
+                # Check for modules used during the build
+                status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], bldlog, cmds, testDef)
+                if 0 != status:
+                    log['status'] = status
+                    log['stdout'] = stdout
+                    log['stderr'] = stderr
+                    return 1
+
+                # get the log of any middleware so we can get its location
+                try:
+                    midlog = testDef.logger.getLog(bldlog['middleware'])
+                    if midlog is not None:
+                        # get the location of the middleware
+                        try:
+                            if midlog['location'] is not None:
+                                # prepend that location to our paths
+                                try:
+                                    self.oldbinpath = os.environ['PATH']
+                                    pieces = self.oldbinpath.split(':')
+                                except KeyError:
+                                    self.oldbinpath = ""
+                                    pieces = []
+                                bindir = os.path.join(midlog['location'], "bin")
+                                pieces.insert(0, bindir)
+                                newpath = ":".join(pieces)
+                                os.environ['PATH'] = newpath
+                                # prepend the loadable lib path
+                                try:
+                                    self.oldldlibpath = os.environ['LD_LIBRARY_PATH']
+                                    pieces = self.oldldlibpath.split(':')
+                                except KeyError:
+                                    self.oldldlibpath = ""
+                                    pieces = []
+                                bindir = os.path.join(midlog['location'], "lib")
+                                pieces.insert(0, bindir)
+                                newpath = ":".join(pieces)
+                                os.environ['LD_LIBRARY_PATH'] = newpath
+
+                                # mark that this was done
+                                self.midpath = True
+                        except KeyError:
+                            # if it was already installed, then no location would be provided
+                            pass
+                        # check for modules required by the middleware
+                        status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], midlog, cmds, testDef)
+                        if 0 != status:
+                            log['status'] = status
+                            log['stdout'] = stdout
+                            log['stderr'] = stderr
+                            return 1
+                except KeyError:
+                    pass
+        except KeyError:
+            log['status'] = 1
+            log['stderr'] = "Parent test build stage was not provided"
+            return 1
+
+        # Apply any requested environment module settings
+        status,stdout,stderr = testDef.modcmd.applyModules(log['section'], cmds, testDef)
+        if 0 != status:
+            log['status'] = status
+            log['stdout'] = stdout
+            log['stderr'] = stderr
+            return 1
+
+        # save our current location and position us to where the tests are located
+        self.cwd = os.getcwd()
+        os.chdir(self.location)
+
+        # all is good
+        return 0
+
+    def resetPaths(self, log, testDef):
+        # Revert any requested environment module settings
+        status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
+        if 0 != status:
+            log['status'] = status
+            log['stdout'] = stdout
+            log['stderr'] = stderr
+            return
+
+        # if we added middleware to the paths, remove it
+        if self.midpath:
+            os.environ['PATH'] = self.oldbinpath
+            os.environ['LD_LIBRARY_PATH'] = self.oldldlibpath
+
+        os.chdir(self.cwd)
+        return
+
+    def collectTests(self, log, cmds):
+        # did they give us a list of specific directories where the desired
+        # tests to be executed reside?
+        if cmds['test_list'] is None:
+            try:
+                if cmds['test_dir'] is not None:
+                    # pick up the executables from the specified directories
+                    dirs = cmds['test_dir'].split()
+                    for dr in dirs:
+                        dr = dr.strip()
+                        # remove any commas and quotes
+                        dr = dr.replace('\"','')
+                        dr = dr.replace(',','')
+                        for dirName, subdirList, fileList in os.walk(dr):
+                            for fname in fileList:
+                                # see if this is an executable
+                                filename = os.path.abspath(os.path.join(dirName,fname))
+                                if os.path.isfile(filename) and os.access(filename, os.X_OK):
+                                    # add this file to our list of tests to execute
+                                    self.tests.append(filename)
+                else:
+                    # get the list of executables from this directory and any
+                    # subdirectories beneath it
+                    for dirName, subdirList, fileList in os.walk("."):
+                        for fname in fileList:
+                            # see if this is an executable
+                            filename = os.path.abspath(os.path.join(dirName,fname))
+                            if os.path.isfile(filename) and os.access(filename, os.X_OK):
+                                # add this file to our list of tests to execute
+                                self.tests.append(filename)
+            except KeyError:
+                # get the list of executables from this directory and any
+                # subdirectories beneath it
+                for dirName, subdirList, fileList in os.walk("."):
+                    for fname in fileList:
+                        # see if this is an executable
+                        filename = os.path.abspath(os.path.join(dirName,fname))
+                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
+                            # add this file to our list of tests to execute
+                            self.tests.append(filename)
+        # If list of tests is provided, use list rather than grabbing all tests
+        else:
+            if cmds['test_dir'] is not None:
+                dirs = cmds['test_dir'].split()
+            else:
+                dirs = ['.']
+            for dr in dirs:
+                dr = dr.strip()
+                dr = dr.replace('\"','')
+                dr = dr.replace(',','')
+                for dirName, subdirList, fileList in os.walk(dr):
+                    for fname_cmd in cmds['test_list'].split("\n"):
+                        fname = fname_cmd.strip().split(" ")[0]
+                        fname_args = " ".join(fname_cmd.strip().split(" ")[1:])
+                        if fname not in fileList:
+                            continue
+                        filename = os.path.abspath(os.path.join(dirName,fname))
+                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
+                            self.tests.append((filename+" "+fname_args).strip())
+        # check that we found something
+        if not self.tests:
+            log['status'] = 1
+            log['stderr'] = "No tests found"
+            os.chdir(cwd)
+            return 1
+
+        # get the "skip" exit status
+        self.skipStatus = int(cmds['skipped'])
+        # get any specified max number of tests to execute
+        if cmds['max_num_tests'] is not None:
+            self.maxTests = int(cmds['max_num_tests'])
+
+        # create a list of the tests that are expected to fail - i.e.,
+        # these are tests that should fail, and therefore "succeed" if
+        # they fail with the designated exit status. Failing with a
+        # different exit status than expected represents a true failure
+        # and must be reported as such
+        fail_tests = cmds['fail_tests']
+        if fail_tests is not None:
+            # it is supposed to be a comma-delimited list of test names
+            # so we split on comma and then strip any remaining whitespace
+            fail_tests = [t.strip() for t in fail_tests.split(",")]
+        else:
+            fail_tests = []
+        # the list of tests expected to fail is given by test name, but
+        # the list of tests we are to execute has been setup in absolute
+        # path form. Thus, scan the two lists and replace the fail_tests
+        # entries with their absolute path equivalents. Note that we don't
+        # bother removing those we don't match as those won't be executed
+        # anyway and thus are irrelevant
+        for i,t in enumerate(fail_tests):
+            for t2 in tests:
+                if t2.split("/")[-1] == t:
+                    fail_tests[i] = t2
+
+        # find the list of expected return codes for tests that are
+        # intended to fail
+        fail_returncodes = cmds['fail_returncodes']
+        if fail_returncodes is not None:
+            # it is supposed to be a comma-delimited list of integers
+            # so we split on comma and then strip any remaining whitespace
+            fail_returncodes = [int(t.strip()) for t in fail_returncodes.split(",")]
+        else:
+            fail_returncodes = []
+
+        # there must be a one-to-one correspondence of fail_returncodes
+        # and fail_tests
+        if len(fail_tests) != len(fail_returncodes):
+            log['status'] = 1
+            if len(fail_tests) > len(fail_returncodes):
+                log['stderr'] = "Not enough return codes were supplied to satisfy the number of tests expected to fail: " + len(fail_returncodes) + ":" + len(fail_tests)
+            else:
+                log['stderr'] = "Too many return codes were supplied to satisfy the number of tests expected to fail: " + len(fail_returncodes) + ":" + len(fail_tests)
+            os.chdir(cwd)
+            return 1
+
+        # construct a dict of usecases for tests expected to fail
+        fail_usecases = {}
+        n = 0
+        for t in fail_tests:
+            fail_usecases[t] = fail_returncodes[n]
+            n += 1
+
+        # record the expected return code for each test - we store this in a
+        # new dictionary that uses the test name as its key. Default to an
+        # expected return code of 0 for any test not in the fail_tests list
+        # cycle across the list of tests
+        for t in tests:
+            if t in fail_usecases:
+                self.expected_returncodes[t] = fail_usecases[t]
+            else:
+                self.expected_returncodes[t] = 0
+
+        # construct the list of tests to be skipped - we will skip the
+        # tests at time of execution and so we leave them in the list
+        # of all tests here
+        skip_tests = cmds['skip_tests']
+        if skip_tests is not None:
+            # it is supposed to be a comma-delimited list of test names
+            # so we split on comma and then strip any remaining whitespace
+            self.skip_tests = [t.strip() for t in skip_tests.split(",")]
+        else:
+            self.skip_tests = []
+        # the list of tests to skip is given by test name, but
+        # the list of tests we are to execute has been setup in absolute
+        # path form. Thus, scan the two lists and replace the skip_tests
+        # entries with their absolute path equivalents. Note that we don't
+        # bother removing those we don't match as those won't be executed
+        # anyway and thus are irrelevant
+        for i,t in enumerate(self.skip_tests):
+            for t2 in tests:
+                if t2.split("/")[-1] == t:
+                    self.skip_tests[i] = t2
+        # all done
+        return 0
+
+    def allocateCluster(self, log, cmds, testDef):
+        self.allocated = False
+        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None:
+            self.allocated = True
+            allocate_cmdargs = shlex.split(cmds['allocate_cmd'])
+            results = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
+            if 0 != results['status']:
+                log['status'] = results['status']
+                log['stderr'] = results['stderr']
+                os.chdir(cwd)
+                return 1
+        return 0
+
+    def runTests(self, log, cmdargs, cmds, testDef):
+        log['testresults'] = []
+        for test in self.tests:
+            testLog = {'test':test}
+            cmdargs.append(test)
+            testLog['cmd'] = " ".join(cmdargs)
+
+            # check if we should skip this test
+            if test in self.skip_tests:
+                # track number of tests we skipped. We record its
+                # status as the one we were told to use for
+                # a "skipped" test since we obviously didn't
+                # really execute it
+                self.numSkip += 1
+                testLog['stdout'] = ""
+                testLog['stderr'] = ""
+                testLog['time'] = 0
+                testLog['status'] = self.skipStatus
+                # clearly mark this as a skipped test
+                testLog['result'] = MTT_TEST_SKIPPED
+                log['testresults'].append(testLog)
+                continue
+
+            harass_exec_ids = testDef.harasser.start(testDef)
+
+            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
+            if harass_check is not None:
+                testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
+                                + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
+                testLog['time'] = sum([r_info[3] for r_info in harass_check[1]])
+                testLog['status'] = 1
+                testLog['result'] = MTT_TEST_FAILED
+                self.finalStatus = 1
+                self.finalError = testLog['stderr']
+                self.numFail += 1
+                testDef.harasser.stop(harass_exec_ids, testDef)
+                continue
+
+            results = testDef.execmd.execute(cmds, cmdargs, testDef)
+
+            testDef.harasser.stop(harass_exec_ids, testDef)
+
+            testLog['status'] = results['status']
+            testLog['stdout'] = results['stdout']
+            testLog['stderr'] = results['stderr']
+            testLog['time'] = results['time']
+
+            try:
+                if results['timeout']:
+                    # the test timed out, so flag it as having exited that way
+                    testLog['result'] = MTT_TEST_TIMED_OUT
+                    self.finalStatus = results['status']
+                    self.finalError = results['stderr']
+                    self.numTimed += 1
+            except:
+                # check the return status - if the test was expected to fail, then
+                # we should see it return the expected code or else we declare it
+                # as having failed
+                if results['status'] != expected_returncodes[test]:
+                    testLog['result'] = MTT_TEST_FAILED
+                    self.finalStatus = results['status']
+                    self.finalError = results['stderr']
+                    self.numFail += 1
+                else:
+                    testLog['result'] = MTT_TEST_PASSED
+                    self.numPass += 1
+
+            log['testresults'].append(testLog)
+            cmdargs = cmdargs[:-1]
+            self.numTests = self.numTests + 1
+            if self.numTests == self.maxTests:
+                break
+        # record the results
+        log['status'] = self.finalStatus
+        log['stderr'] = self.finalError
+        log['numTests'] = self.numTests
+        log['numPass'] = self.numPass
+        log['numSkip'] = self.numSkip
+        log['numFail'] = self.numFail
+        log['numTimed'] = self.numTimed
+        try:
+            log['np'] = cmds['np']
+        except KeyError:
+            log['np'] = None
+        return
+
+    def deallocateCluster(self, log, cmds, testDef):
+        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated:
+            deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
+            results = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
+            if 0 != results['status'] and log is not None:
+                log['status'] = results['status']
+                log['stderr'] = results['stderr']
+                return 1
+            self.allocated = False
+        return 0
 

--- a/pylib/Tools/Launcher/LauncherMTTTool.py
+++ b/pylib/Tools/Launcher/LauncherMTTTool.py
@@ -360,7 +360,7 @@ class LauncherMTTTool(IPlugin):
                 testLog['time'] = 0
                 testLog['status'] = self.skipStatus
                 # clearly mark this as a skipped test
-                testLog['result'] = MTT_TEST_SKIPPED
+                testLog['result'] = testDef.MTT_TEST_SKIPPED
                 log['testresults'].append(testLog)
                 continue
 
@@ -372,7 +372,7 @@ class LauncherMTTTool(IPlugin):
                                 + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
                 testLog['time'] = sum([r_info[3] for r_info in harass_check[1]])
                 testLog['status'] = 1
-                testLog['result'] = MTT_TEST_FAILED
+                testLog['result'] = testDef.MTT_TEST_FAILED
                 self.finalStatus = 1
                 self.finalError = testLog['stderr']
                 self.numFail += 1
@@ -391,7 +391,7 @@ class LauncherMTTTool(IPlugin):
             try:
                 if results['timeout']:
                     # the test timed out, so flag it as having exited that way
-                    testLog['result'] = MTT_TEST_TIMED_OUT
+                    testLog['result'] = testDef.MTT_TEST_TIMED_OUT
                     self.finalStatus = results['status']
                     self.finalError = results['stderr']
                     self.numTimed += 1
@@ -400,12 +400,12 @@ class LauncherMTTTool(IPlugin):
                 # we should see it return the expected code or else we declare it
                 # as having failed
                 if results['status'] != expected_returncodes[test]:
-                    testLog['result'] = MTT_TEST_FAILED
+                    testLog['result'] = testDef.MTT_TEST_FAILED
                     self.finalStatus = results['status']
                     self.finalError = results['stderr']
                     self.numFail += 1
                 else:
-                    testLog['result'] = MTT_TEST_PASSED
+                    testLog['result'] = testDef.MTT_TEST_PASSED
                     self.numPass += 1
 
             log['testresults'].append(testLog)

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -86,10 +86,9 @@ class OpenMPI(LauncherMTTTool):
 
     def deactivate(self):
         IPlugin.deactivate(self)
-        if self.allocated and self.testDef and self.cmds:
+        if self.testDef and self.cmds:
             deallocate_cmdargs = shlex.split(self.cmds['deallocate_cmd'])
-            _status,_stdout,_stderr,_time = self.testDef.execmd.execute(self.cmds, deallocate_cmdargs, self.testDef)
-            self.allocated = False
+            self.deallocateCluster(None, self.cmds, self.testDef)
 
     def print_name(self):
         return "OpenMPI"
@@ -101,11 +100,7 @@ class OpenMPI(LauncherMTTTool):
         return
 
     def execute(self, log, keyvals, testDef):
-
         self.testDef = testDef
-
-        midpath = False
-
         testDef.logger.verbose_print("OpenMPI Launcher")
 
         # parse any provided options - these will override the defaults
@@ -113,185 +108,29 @@ class OpenMPI(LauncherMTTTool):
         testDef.parseOptions(log, self.options, keyvals, cmds)
         self.cmds = cmds
 
-        # check the log for the title so we can
-        # see if this is setting our default behavior
-        try:
-            if log['section'] is not None:
-                if "Default" in log['section']:
-                    # this section contains default settings
-                    # for this launcher
-                    myopts = {}
-                    testDef.parseOptions(log, self.options, keyvals, myopts)
-                    # transfer the findings into our local storage
-                    keys = list(self.options.keys())
-                    optkeys = list(myopts.keys())
-                    for optkey in optkeys:
-                        for key in keys:
-                            if key == optkey:
-                                self.options[key] = (myopts[optkey],self.options[key][1])
-                    # we captured the default settings, so we can
-                    # now return with success
-                    log['status'] = 0
-                    return
-        except KeyError:
-            # error - the section should have been there
-            log['status'] = 1
-            log['stderr'] = "Section not specified"
-            return
-        # must be executing a test of some kind - the install stage
-        # must be specified so we can find the tests to be run
-        try:
-            parent = keyvals['parent']
-            if parent is not None:
-                # get the log entry as it contains the location
-                # of the built tests
-                bldlog = testDef.logger.getLog(parent)
-                try:
-                    location = bldlog['location']
-                except KeyError:
-                    # if it wasn't recorded, then there is nothing
-                    # we can do
-                    log['status'] = 1
-                    log['stderr'] = "Location of built tests was not provided"
-                    return
-                # check for modules used during the build of these tests
-                status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], bldlog, cmds, testDef)
-                if 0 != status:
-                    log['status'] = status
-                    log['stdout'] = stdout
-                    log['stderr'] = stderr
-                    return
-
-                # get the log of any middleware so we can get its location
-                try:
-                    midlog = testDef.logger.getLog(bldlog['middleware'])
-                    if midlog is not None:
-                        # get the location of the middleware
-                        try:
-                            if midlog['location'] is not None:
-                                # prepend that location to our paths
-                                try:
-                                    oldbinpath = os.environ['PATH']
-                                    pieces = oldbinpath.split(':')
-                                except KeyError:
-                                    oldbinpath = ""
-                                    pieces = []
-                                bindir = os.path.join(midlog['location'], "bin")
-                                pieces.insert(0, bindir)
-                                newpath = ":".join(pieces)
-                                os.environ['PATH'] = newpath
-                                # prepend the loadable lib path
-                                try:
-                                    oldldlibpath = os.environ['LD_LIBRARY_PATH']
-                                    pieces = oldldlibpath.split(':')
-                                except KeyError:
-                                    oldldlibpath = ""
-                                    pieces = []
-                                bindir = os.path.join(midlog['location'], "lib")
-                                pieces.insert(0, bindir)
-                                newpath = ":".join(pieces)
-                                os.environ['LD_LIBRARY_PATH'] = newpath
-
-                                # mark that this was done
-                                midpath = True
-                        except KeyError:
-                            # if it was already installed, then no location would be provided
-                            pass
-                        # check for modules required by the middleware
-                        status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], midlog, cmds, testDef)
-                        if 0 != status:
-                            log['status'] = status
-                            log['stdout'] = stdout
-                            log['stderr'] = stderr
-                            return
-                except KeyError:
-                    pass
-        except KeyError:
-            log['status'] = 1
-            log['stderr'] = "Parent test build stage was not provided"
+        # update our defaults, if requested
+        status = self.updateDefaults(log, self.options, keyvals)
+        if status != 0:
+            # indicates there is nothing more for us to do - status
+            # et al is already in the log
             return
 
-        # Apply any requested environment module settings
-        status,stdout,stderr = testDef.modcmd.applyModules(log['section'], cmds, testDef)
-        if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
+        # now let's setup the PATH and LD_LIBRARY_PATH as reqd
+        status = self.setupPaths(log, keyvals, cmds, testDef)
+        if status != 0:
+            # something went wrong - error is in the log
             return
 
-        # now ready to execute the test - we are pointed at the middleware
-        # and have obtained the list of any modules associated with it. We need
-        # to change to the test location and begin executing, first saving
-        # our current location so we can return when done
-        cwd = os.getcwd()
-        os.chdir(location)
-        # did they give us a list of specific directories where the desired
-        # tests to be executed reside?
+        # collect the tests to be considered
         tests = []
-        if cmds['test_list'] is None:
-            try:
-                if cmds['test_dir'] is not None:
-                    # pick up the executables from the specified directories
-                    dirs = cmds['test_dir'].split()
-                    for dr in dirs:
-                        dr = dr.strip()
-                        # remove any commas and quotes
-                        dr = dr.replace('\"','')
-                        dr = dr.replace(',','')
-                        for dirName, subdirList, fileList in os.walk(dr):
-                            for fname in fileList:
-                                # see if this is an executable
-                                filename = os.path.abspath(os.path.join(dirName,fname))
-                                if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                                    # add this file to our list of tests to execute
-                                    tests.append(filename)
-                else:
-                    # get the list of executables from this directory and any
-                    # subdirectories beneath it
-                    for dirName, subdirList, fileList in os.walk("."):
-                        for fname in fileList:
-                            # see if this is an executable
-                            filename = os.path.abspath(os.path.join(dirName,fname))
-                            if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                                # add this file to our list of tests to execute
-                                tests.append(filename)
-            except KeyError:
-                # get the list of executables from this directory and any
-                # subdirectories beneath it
-                for dirName, subdirList, fileList in os.walk("."):
-                    for fname in fileList:
-                        # see if this is an executable
-                        filename = os.path.abspath(os.path.join(dirName,fname))
-                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                            # add this file to our list of tests to execute
-                            tests.append(filename)
-        # If list of tests is provided, use list rather than grabbing all tests
-        else:
-            if cmds['test_dir'] is not None:
-                dirs = cmds['test_dir'].split()
-            else:
-                dirs = ['.']
-            for dr in dirs:
-                dr = dr.strip()
-                dr = dr.replace('\"','')
-                dr = dr.replace(',','')
-                for dirName, subdirList, fileList in os.walk(dr):
-                    for fname in cmds['test_list'].split(","):
-                        fname = fname.strip()
-                        if fname not in fileList:
-                            continue
-                        filename = os.path.abspath(os.path.join(dirName,fname))
-                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                            tests.append(filename)
-
+        self.collectTests(log, cmds, tests)
         # check that we found something
         if not tests:
             log['status'] = 1
             log['stderr'] = "No tests found"
-            os.chdir(cwd)
+            self.resetPaths(log, testDef)
             return
-        # get the "skip" exit status
-        skipStatus = int(cmds['skipped'])
+
         # assemble the command
         cmdargs = cmds['command'].split()
         if cmds['np'] is not None:
@@ -310,145 +149,20 @@ class OpenMPI(LauncherMTTTool):
             optArgs = cmds['options'].split(',')
             for arg in optArgs:
                 cmdargs.append(arg.strip())
-        # cycle thru the list of tests and execute each of them
-        log['testresults'] = []
-        finalStatus = 0
-        finalError = ""
-        numTests = 0
-        numPass = 0
-        numSkip = 0
-        numFail = 0
-        if cmds['max_num_tests'] is not None:
-            maxTests = int(cmds['max_num_tests'])
-        else:
-            maxTests = 10000000
-
-        fail_tests = cmds['fail_tests']
-        if fail_tests is not None:
-            fail_tests = [t.strip() for t in fail_tests.split(",")]
-        else:
-            fail_tests = []
-        for i,t in enumerate(fail_tests):
-            for t2 in tests:
-                if t2.split("/")[-1] == t:
-                    fail_tests[i] = t2
-        fail_returncodes = cmds['fail_returncodes']
-        if fail_returncodes is not None:
-            fail_returncodes = [int(t.strip()) for t in fail_returncodes.split(",")]
-
-        if fail_tests is None:
-            expected_returncodes = {test:0 for test in tests}
-        else:
-            if fail_returncodes is None:
-                expected_returncodes = {test:(None if test in fail_tests else 0) for test in tests}
-            else:
-                fail_returncodes = {test:rtncode for test,rtncode in zip(fail_tests,fail_returncodes)}
-                expected_returncodes = {test:(fail_returncodes[test] if test in fail_returncodes else 0) for test in tests}
 
         # Allocate cluster
-        self.allocated = False
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None:
-            self.allocated = True
-            allocate_cmdargs = shlex.split(cmds['allocate_cmd'])
-            _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
-            if 0 != _status:
-                log['status'] = _status
-                log['stderr'] = _stderr
-                os.chdir(cwd)
-                return
-
-        for test in tests:
-            # Skip tests that are in "skip_tests" ini input
-            if cmds['skip_tests'] is not None and test.split('/')[-1] in [st.strip() for st in cmds['skip_tests'].split()]:
-                numTests += 1
-                numSkip += 1
-                if numTests == maxTests:
-                    break
-                continue
-            testLog = {'test':test}
-            cmdargs.append(test)
-            testLog['cmd'] = " ".join(cmdargs)
-
-            harass_exec_ids = testDef.harasser.start(testDef)
-
-            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
-            if harass_check is not None:
-                testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
-                                + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
-                testLog['time'] = sum([r_info[3] for r_info in harass_check[1]])
-                testLog['status'] = 1
-                finalStatus = 1
-                finalError = testLog['stderr']
-                numFail = numFail + 1
-                testDef.harasser.stop(harass_exec_ids, testDef)
-                continue
-
-            status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
-
-            testDef.harasser.stop(harass_exec_ids, testDef)
-
-            if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
-                if expected_returncodes[test] == 0:
-                    finalStatus = status
-                else:
-                    finalStatus = 1
-                finalError = stderr
-            if (expected_returncodes[test] is None and 0 != status) or (expected_returncodes[test] == status):
-                numPass = numPass + 1
-            elif skipStatus == status:
-                numSkip = numSkip + 1
-            else:
-                numFail = numFail + 1
-            if expected_returncodes[test] == 0:
-                testLog['status'] = status
-            else:
-                if status == expected_returncodes[test]:
-                    testLog['status'] = 0
-                else:
-                    testLog['status'] = 1
-            testLog['stdout'] = stdout
-            testLog['stderr'] = stderr
-            testLog['time'] = time
-            log['testresults'].append(testLog)
-            cmdargs = cmdargs[:-1]
-            numTests = numTests + 1
-            if numTests == maxTests:
-                break
-
-        # Deallocate cluster
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated:
-            deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
-            _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
-            if 0 != _status:
-                log['status'] = _status
-                log['stderr'] = _stderr
-                os.chdir(cwd)
-                return
-            self.allocated = False
-
-        log['status'] = finalStatus
-        log['stderr'] = finalError
-        log['numTests'] = numTests
-        log['numPass'] = numPass
-        log['numSkip'] = numSkip
-        log['numFail'] = numFail
-        try:
-            log['np'] = cmds['np']
-        except KeyError:
-            log['np'] = None
-
-        # Revert any requested environment module settings
-        status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
+        status = self.allocateCluster(log, cmds, testDef)
         if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
+            self.resetPaths(log, testDef)
             return
 
-        # if we added middleware to the paths, remove it
-        if midpath:
-            os.environ['PATH'] = oldbinpath
-            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
+        # execute the tests
+        self.runTests(log, cmdargs, cmds, testDef)
 
-        os.chdir(cwd)
+        # Deallocate cluster
+        self.deallocateCluster(log, cmds, testDef)
+
+        # reset our paths and return us to our cwd
+        self.resetPaths(log, testDef)
+
         return

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -145,6 +145,10 @@ class OpenMPI(LauncherMTTTool):
         if cmds['timeout'] is not None:
             cmdargs.append("--timeout")
             cmdargs.append(cmds['timeout'])
+            # remove this directive to ensure the cmd executor
+            # does not also set a timeout - avoids a race
+            # condition
+            del cmds['timeout']
         if cmds['options'] is not None:
             optArgs = cmds['options'].split(',')
             for arg in optArgs:

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -159,7 +159,7 @@ class PRRTE(LauncherMTTTool):
         # start the PRRTE DVM
         process = Popen(['prte'], stdout=PIPE, stderr=PIPE)
         # wait a little for the prte daemon to start
-        time.sleep(int(self.options['waittime']))
+        time.sleep(int(cmds['waittime']))
 
         # execute the tests
         self.runTests(log, cmdargs, cmds, testDef)

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
-# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -87,10 +87,9 @@ class PRRTE(LauncherMTTTool):
 
     def deactivate(self):
         IPlugin.deactivate(self)
-        if self.allocated and self.testDef and self.cmds:
+        if self.testDef and self.cmds:
             deallocate_cmdargs = shlex.split(self.cmds['deallocate_cmd'])
-            _status,_stdout,_stderr,_time = self.testDef.execmd.execute(self.cmds, deallocate_cmdargs, self.testDef)
-            self.allocated = False
+            self.deallocateCluster(None, self.cmds, self.testDef)
 
     def print_name(self):
         return "PRRTE"
@@ -102,11 +101,7 @@ class PRRTE(LauncherMTTTool):
         return
 
     def execute(self, log, keyvals, testDef):
-
         self.testDef = testDef
-
-        midpath = False
-
         testDef.logger.verbose_print("PRRTE Launcher")
 
         # parse any provided options - these will override the defaults
@@ -114,185 +109,29 @@ class PRRTE(LauncherMTTTool):
         testDef.parseOptions(log, self.options, keyvals, cmds)
         self.cmds = cmds
 
-        # check the log for the title so we can
-        # see if this is setting our default behavior
-        try:
-            if log['section'] is not None:
-                if "Default" in log['section']:
-                    # this section contains default settings
-                    # for this launcher
-                    myopts = {}
-                    testDef.parseOptions(log, self.options, keyvals, myopts)
-                    # transfer the findings into our local storage
-                    keys = list(self.options.keys())
-                    optkeys = list(myopts.keys())
-                    for optkey in optkeys:
-                        for key in keys:
-                            if key == optkey:
-                                self.options[key] = (myopts[optkey],self.options[key][1])
-                    # we captured the default settings, so we can
-                    # now return with success
-                    log['status'] = 0
-                    return
-        except KeyError:
-            # error - the section should have been there
-            log['status'] = 1
-            log['stderr'] = "Section not specified"
-            return
-        # must be executing a test of some kind - the install stage
-        # must be specified so we can find the tests to be run
-        try:
-            parent = keyvals['parent']
-            if parent is not None:
-                # get the log entry as it contains the location
-                # of the built tests
-                bldlog = testDef.logger.getLog(parent)
-                try:
-                    location = bldlog['location']
-                except KeyError:
-                    # if it wasn't recorded, then there is nothing
-                    # we can do
-                    log['status'] = 1
-                    log['stderr'] = "Location of built tests was not provided"
-                    return
-                # check for modules used during the build of these tests
-                status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], bldlog, cmds, testDef)
-                if 0 != status:
-                    log['status'] = status
-                    log['stdout'] = stdout
-                    log['stderr'] = stderr
-                    return
-
-                # get the log of any middleware so we can get its location
-                try:
-                    midlog = testDef.logger.getLog(bldlog['middleware'])
-                    if midlog is not None:
-                        # get the location of the middleware
-                        try:
-                            if midlog['location'] is not None:
-                                # prepend that location to our paths
-                                try:
-                                    oldbinpath = os.environ['PATH']
-                                    pieces = oldbinpath.split(':')
-                                except KeyError:
-                                    oldbinpath = ""
-                                    pieces = []
-                                bindir = os.path.join(midlog['location'], "bin")
-                                pieces.insert(0, bindir)
-                                newpath = ":".join(pieces)
-                                os.environ['PATH'] = newpath
-                                # prepend the loadable lib path
-                                try:
-                                    oldldlibpath = os.environ['LD_LIBRARY_PATH']
-                                    pieces = oldldlibpath.split(':')
-                                except KeyError:
-                                    oldldlibpath = ""
-                                    pieces = []
-                                bindir = os.path.join(midlog['location'], "lib")
-                                pieces.insert(0, bindir)
-                                newpath = ":".join(pieces)
-                                os.environ['LD_LIBRARY_PATH'] = newpath
-
-                                # mark that this was done
-                                midpath = True
-                        except KeyError:
-                            # if it was already installed, then no location would be provided
-                            pass
-                        # check for modules required by the middleware
-                        status,stdout,stderr = testDef.modcmd.checkForModules(log['section'], midlog, cmds, testDef)
-                        if 0 != status:
-                            log['status'] = status
-                            log['stdout'] = stdout
-                            log['stderr'] = stderr
-                            return
-                except KeyError:
-                    pass
-        except KeyError:
-            log['status'] = 1
-            log['stderr'] = "Parent test build stage was not provided"
+        # update our defaults, if requested
+        status = self.updateDefaults(log, self.options, keyvals)
+        if status != 0:
+            # indicates there is nothing more for us to do - status
+            # et al is already in the log
             return
 
-        # Apply any requested environment module settings
-        status,stdout,stderr = testDef.modcmd.applyModules(log['section'], cmds, testDef)
-        if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
+        # now let's setup the PATH and LD_LIBRARY_PATH as reqd
+        status = self.setupPaths(log, keyvals, cmds, testDef)
+        if status != 0:
+            # something went wrong - error is in the log
             return
 
-        # now ready to execute the test - we are pointed at the middleware
-        # and have obtained the list of any modules associated with it. We need
-        # to change to the test location and begin executing, first saving
-        # our current location so we can return when done
-        cwd = os.getcwd()
-        os.chdir(location)
-        # did they give us a list of specific directories where the desired
-        # tests to be executed reside?
+        # collect the tests to be considered
         tests = []
-        if cmds['test_list'] is None:
-            try:
-                if cmds['test_dir'] is not None:
-                    # pick up the executables from the specified directories
-                    dirs = cmds['test_dir'].split()
-                    for dr in dirs:
-                        dr = dr.strip()
-                        # remove any commas and quotes
-                        dr = dr.replace('\"','')
-                        dr = dr.replace(',','')
-                        for dirName, subdirList, fileList in os.walk(dr):
-                            for fname in fileList:
-                                # see if this is an executable
-                                filename = os.path.abspath(os.path.join(dirName,fname))
-                                if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                                    # add this file to our list of tests to execute
-                                    tests.append(filename)
-                else:
-                    # get the list of executables from this directory and any
-                    # subdirectories beneath it
-                    for dirName, subdirList, fileList in os.walk("."):
-                        for fname in fileList:
-                            # see if this is an executable
-                            filename = os.path.abspath(os.path.join(dirName,fname))
-                            if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                                # add this file to our list of tests to execute
-                                tests.append(filename)
-            except KeyError:
-                # get the list of executables from this directory and any
-                # subdirectories beneath it
-                for dirName, subdirList, fileList in os.walk("."):
-                    for fname in fileList:
-                        # see if this is an executable
-                        filename = os.path.abspath(os.path.join(dirName,fname))
-                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                            # add this file to our list of tests to execute
-                            tests.append(filename)
-        # If list of tests is provided, use list rather than grabbing all tests
-        else:
-            if cmds['test_dir'] is not None:
-                dirs = cmds['test_dir'].split()
-            else:
-                dirs = ['.']
-            for dr in dirs:
-                dr = dr.strip()
-                dr = dr.replace('\"','')
-                dr = dr.replace(',','')
-                for dirName, subdirList, fileList in os.walk(dr):
-                    for fname in cmds['test_list'].split(","):
-                        fname = fname.strip()
-                        if fname not in fileList:
-                            continue
-                        filename = os.path.abspath(os.path.join(dirName,fname))
-                        if os.path.isfile(filename) and os.access(filename, os.X_OK):
-                            tests.append(filename)
-
+        self.collectTests(log, cmds, tests)
         # check that we found something
         if not tests:
             log['status'] = 1
             log['stderr'] = "No tests found"
-            os.chdir(cwd)
+            self.resetPaths(log, testDef)
             return
-        # get the "skip" exit status
-        skipStatus = int(cmds['skipped'])
+
         # assemble the command
         cmdargs = cmds['command'].split()
         if cmds['np'] is not None:
@@ -312,151 +151,27 @@ class PRRTE(LauncherMTTTool):
             for arg in optArgs:
                 cmdargs.append(arg.strip())
 
-        # cycle thru the list of tests and execute each of them
-        log['testresults'] = []
-        finalStatus = 0
-        finalError = ""
-        numTests = 0
-        numPass = 0
-        numSkip = 0
-        numFail = 0
-        if cmds['max_num_tests'] is not None:
-            maxTests = int(cmds['max_num_tests'])
-        else:
-            maxTests = 10000000
-
-        fail_tests = cmds['fail_tests']
-        if fail_tests is not None:
-            fail_tests = [t.strip() for t in fail_tests.split(",")]
-        else:
-            fail_tests = []
-        for i,t in enumerate(fail_tests):
-            for t2 in tests:
-                if t2.split("/")[-1] == t:
-                    fail_tests[i] = t2
-        fail_returncodes = cmds['fail_returncodes']
-        if fail_returncodes is not None:
-            fail_returncodes = [int(t.strip()) for t in fail_returncodes.split(",")]
-
-        if fail_tests is None:
-            expected_returncodes = {test:0 for test in tests}
-        else:
-            if fail_returncodes is None:
-                expected_returncodes = {test:(None if test in fail_tests else 0) for test in tests}
-            else:
-                fail_returncodes = {test:rtncode for test,rtncode in zip(fail_tests,fail_returncodes)}
-                expected_returncodes = {test:(fail_returncodes[test] if test in fail_returncodes else 0) for test in tests}
-
         # Allocate cluster
-        self.allocated = False
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None:
-            self.allocated = True
-            allocate_cmdargs = shlex.split(cmds['allocate_cmd'])
-            _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, allocate_cmdargs, testDef)
-            if 0 != _status:
-                log['status'] = _status
-                log['stderr'] = _stderr
-                os.chdir(cwd)
-                return
+        status = self.allocateCluster(log, cmds, testDef)
+        if 0 != status:
+            self.resetPaths(log, testDef)
+            return
 
         # start the PRRTE DVM
         process = Popen(['prte'], stdout=PIPE, stderr=PIPE)
 
-        for test in tests:
-            # Skip tests that are in "skip_tests" ini input
-            if cmds['skip_tests'] is not None and test.split('/')[-1] in [st.strip() for st in cmds['skip_tests'].split()]:
-                numTests += 1
-                numSkip += 1
-                if numTests == maxTests:
-                    break
-                continue
-            testLog = {'test':test}
-            cmdargs.append(test)
-            testLog['cmd'] = " ".join(cmdargs)
-
-            harass_exec_ids = testDef.harasser.start(testDef)
-
-            harass_check = testDef.harasser.check(harass_exec_ids, testDef)
-            if harass_check is not None:
-                testLog['stderr'] = 'Not all harasser scripts started. These failed to start: ' \
-                                + ','.join([h_info[1]['start_script'] for h_info in harass_check[0]])
-                testLog['time'] = sum([r_info[3] for r_info in harass_check[1]])
-                testLog['status'] = 1
-                finalStatus = 1
-                finalError = testLog['stderr']
-                numFail = numFail + 1
-                testDef.harasser.stop(harass_exec_ids, testDef)
-                continue
-
-            status,stdout,stderr,time = testDef.execmd.execute(cmds, cmdargs, testDef)
-
-            testDef.harasser.stop(harass_exec_ids, testDef)
-
-            if ((expected_returncodes[test] is None and 0 == status) or (expected_returncodes[test] is not None and expected_returncodes[test] != status)) and skipStatus != status and 0 == finalStatus:
-                if expected_returncodes[test] == 0:
-                    finalStatus = status
-                else:
-                    finalStatus = 1
-                finalError = stderr
-            if (expected_returncodes[test] is None and 0 != status) or (expected_returncodes[test] == status):
-                numPass = numPass + 1
-            elif skipStatus == status:
-                numSkip = numSkip + 1
-            else:
-                numFail = numFail + 1
-            if expected_returncodes[test] == 0:
-                testLog['status'] = status
-            else:
-                if status == expected_returncodes[test]:
-                    testLog['status'] = 0
-                else:
-                    testLog['status'] = 1
-            testLog['stdout'] = stdout
-            testLog['stderr'] = stderr
-            testLog['time'] = time
-            log['testresults'].append(testLog)
-            cmdargs = cmdargs[:-1]
-            numTests = numTests + 1
-            if numTests == maxTests:
-                break
+        # execute the tests
+        self.runTests(log, cmdargs, cmds, testDef)
 
         # stop the PRRTE DVM
-        status,stdout,stderr = testDef.execmd.execute(cmds, ["prun", "--terminate"], testDef)
+        results = testDef.execmd.execute(cmds, ["prun", "--terminate"], testDef)
 
         # Deallocate cluster
-        if cmds['allocate_cmd'] is not None and cmds['deallocate_cmd'] is not None and self.allocated:
-            deallocate_cmdargs = shlex.split(cmds['deallocate_cmd'])
-            _status,_stdout,_stderr,_time = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
-            if 0 != _status:
-                log['status'] = _status
-                log['stderr'] = _stderr
-                os.chdir(cwd)
-                return
-            self.allocated = False
-
-        log['status'] = finalStatus
-        log['stderr'] = finalError
-        log['numTests'] = numTests
-        log['numPass'] = numPass
-        log['numSkip'] = numSkip
-        log['numFail'] = numFail
-        try:
-            log['np'] = cmds['np']
-        except KeyError:
-            log['np'] = None
-
-        # Revert any requested environment module settings
-        status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
+        status = self.deallocateCluster(log, cmds, testDef)
         if 0 != status:
-            log['status'] = status
-            log['stdout'] = stdout
-            log['stderr'] = stderr
+            self.resetPaths(log, testDef)
             return
 
-        # if we added middleware to the paths, remove it
-        if midpath:
-            os.environ['PATH'] = oldbinpath
-            os.environ['LD_LIBRARY_PATH'] = oldldlibpath
-
-        os.chdir(cwd)
+        # reset our paths and return us to our cwd
+        self.resetPaths(log, testDef)
         return

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -146,6 +146,10 @@ class PRRTE(LauncherMTTTool):
         if cmds['timeout'] is not None:
             cmdargs.append("--timeout")
             cmdargs.append(cmds['timeout'])
+            # remove this directive to ensure the cmd executor
+            # does not also set a timeout - avoids a race
+            # condition
+            del cmds['timeout']
         if cmds['options'] is not None:
             optArgs = cmds['options'].split(',')
             for arg in optArgs:

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -41,6 +41,7 @@ import subprocess
 # @param test_list                 List of tests to run, default is all
 # @param allocate_cmd              Command to use for allocating nodes from the resource manager
 # @param deallocate_cmd            Command to use for deallocating nodes from the resource manager
+# @param dependencies              List of dependencies specified as the build stage name
 # @}
 class SLURM(LauncherMTTTool):
 
@@ -70,6 +71,7 @@ class SLURM(LauncherMTTTool):
         self.options['test_list'] = (None, "List of tests to run, default is all")
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
+        self.options['dependencies'] = (None, "List of dependencies specified as the build stage name - e.g., MiddlwareBuild_package to be added to configure using --with-package=location")
 
         self.allocated = False
         self.testDef = None
@@ -85,7 +87,7 @@ class SLURM(LauncherMTTTool):
 
     def deactivate(self):
         IPlugin.deactivate(self)
-        if self.testDef and self.cmds:
+        if self.testDef and self.cmds and self.cmds['deallocate_cmd'] is not None:
             deallocate_cmdargs = shlex.split(self.cmds['deallocate_cmd'])
             self.deallocateCluster(None, self.cmds, self.testDef)
 
@@ -110,7 +112,7 @@ class SLURM(LauncherMTTTool):
 
         # check the log for the title so we can
         # see if this is setting our default behavior
-        status = self.updateDefaults(log, self.options, keyvals)
+        status = self.updateDefaults(log, self.options, keyvals, testDef)
         if status != 0:
             # indicates there is nothing more for us to do - status
             # et al is already in the log
@@ -123,12 +125,10 @@ class SLURM(LauncherMTTTool):
             return
 
         # collect the tests to be considered
-        tests = []
-        self.collectTests(log, cmds, tests)
+        status = self.collectTests(log, cmds)
         # check that we found something
-        if not tests:
-            log['status'] = 1
-            log['stderr'] = "No tests found"
+        if status != 0:
+            # something went wrong - error is in the log
             self.resetPaths(log, testDef)
             return
 

--- a/pylib/Utilities/Compilers.py
+++ b/pylib/Utilities/Compilers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -181,14 +181,14 @@ class Compilers(BaseMTTUtility):
 
         # Attempt to compile it
         mycmdargs = [compiler, "-c", "spastic.c"]
-        status, stdout, stderr, _ = testDef.execmd.execute(None, mycmdargs, testDef)
+        results = testDef.execmd.execute(None, mycmdargs, testDef)
 
         # cleanup the test
         os.remove("spastic.c")
         if os.path.exists("spastic.o"):
             os.remove("spastic.o")
 
-        if 0 == status:
+        if 0 == results['status']:
             return True
         return False
 
@@ -215,6 +215,6 @@ class Compilers(BaseMTTUtility):
     def check_version(self, compiler, version, testDef):
         # try the universal version option
         mycmdargs = [compiler, version]
-        status, stdout, stderr, _ = testDef.execmd.execute(None, mycmdargs, testDef)
-        return status, stdout
+        results = testDef.execmd.execute(None, mycmdargs, testDef)
+        return results['status'], results['stdout']
 

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -100,9 +100,9 @@ class ExecuteCmd(BaseMTTUtility):
 
         # register the signal handler for timeout detection
         timeoutset = False
-        if options is not None and 'fail_timeout' in options:
+        if options is not None and 'timeout' in options:
             signal.signal(signal.SIGALRM, handler)
-            signal.alarm(options['fail_timeout'])
+            signal.alarm(options['timeout'])
             timeoutset = True
 
         # define storage to catch the output

--- a/pylib/Utilities/MPIVersion.py
+++ b/pylib/Utilities/MPIVersion.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -105,19 +105,19 @@ int main(int argc, char **argv) {
     return 0;
 }""")
             fh.close()
-        status, _, _, _ = testDef.execmd.execute(None, shlex.split('mpicc -o mpi_get_version mpi_get_version.c'), testDef)
-        if 0 != status:
-            status, _, _, _ = testDef.execmd.execute(None, shlex.split('cc -o mpi_get_version mpi_get_version.c'), testDef)
-            if 0 != status:
+        results = testDef.execmd.execute(None, shlex.split('mpicc -o mpi_get_version mpi_get_version.c'), testDef)
+        if 0 != results['status']:
+            results = testDef.execmd.execute(None, shlex.split('cc -o mpi_get_version mpi_get_version.c'), testDef)
+            if 0 != results['status']:
                 os.chdir("..")
                 return None
 
-        status, stdout, _, _ = testDef.execmd.execute(None, shlex.split('sh -c "mpiexec ./mpi_get_version |uniq -c"'), testDef)
-        if 0 != status:
-            status, stdout, _, _ = testDef.execmd.execute(None, shlex.split('sh -c "aprun ./mpi_get_version |uniq -c"'), testDef)
-            if 0 != status:
-                status, stdout, _, _ = testDef.execmd.execute(None, shlex.split('sh -c "./mpi_get_version |uniq -c"'), testDef)
-                if 0 != status:
+        results = testDef.execmd.execute(None, shlex.split('sh -c "mpiexec ./mpi_get_version |uniq -c"'), testDef)
+        if 0 != results['status']:
+            results = testDef.execmd.execute(None, shlex.split('sh -c "aprun ./mpi_get_version |uniq -c"'), testDef)
+            if 0 != results['status']:
+                results = testDef.execmd.execute(None, shlex.split('sh -c "./mpi_get_version |uniq -c"'), testDef)
+                if 0 != results['status']:
                     os.chdir("..")
                     return None
 


### PR DESCRIPTION
Every time we want to extend the return values from ExecuteCmd, we have
to go back and change every place we call it. This isn't supportable in
the long term. So instead of passing back arrays of values, return a
dictionary instead. This makes it possible to extend the return values
from ExecuteCmd without having to modify any existing code.

Sadly, it did mean having to modify everyone who currently uses that
plugin. Thus, this PR touches a number of plugins - but fortunately
doesn't alter their logic.

The primary driver for the changes was the need to refactor the various
Launchers. There was a ton of copy/paste'd code in them - turned out
that the differences were actually rather small. So instead of having
all that code duplication, put the common code in the LauncherMTT stage
plugin from which all the Launcher's derive.

Reason for doing this is that there were some significant problems in
the existing launchers:

* the timeout support was never implemented, and so we didn't detect or
properly handle tests that simply hung/spun forever

* the designation of skipped vs failed tests was incorrect. I think we
got a little too clever in coding things to the minimum number of lines
of code.

* using the return status as an indicator of "skipped" and friends meant
that we were losing the actual exit code of the test.

* we incorrectly included the #skipped tests in the #tests being
executed, thus causing us to execute fewer tests than the user had
specified

This has now been fixed. The logic for creating the lists of skipped and
expected-to-fail tests is all centralized and broken into distinct
steps. Yes, it is a few more lines of code - but hopefully it is a
little easier to read and understand.

Executing the tests is likewise centralized. Each launcher is
responsible for just creating its cmd line for executing the tests.
Everything else is just done with calls to the common code.

Still up: updating the reporters to properly understand the new tag
designators for test results (skipped, failed as expected, etc.)

Signed-off-by: Ralph Castain <rhc@pmix.org>