### PR TITLE
Protect log interpolation and handle mixed "lib" locations

### DIFF
--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -185,20 +185,35 @@ class PMIxUnit(TestRunMTTStage):
                 except KeyError:
                     oldldlibpath = ""
                     pieces = []
-                bindir = os.path.join(midlog['location'], "lib")
-                pieces.insert(0, bindir)
+                libdir = os.path.join(midlog['location'], "lib")
+                if not os.path.exists(libdir) or not os.path.isdir(libdir):
+                    libdir = os.path.join(midlog['location'], "lib64")
+                pieces.insert(0, libdir)
                 newpath = ":".join(pieces)
                 os.environ['LD_LIBRARY_PATH'] = newpath
                 # see if there is a Python subdirectory
-                listing = os.listdir(bindir)
+                listing = os.listdir(libdir)
                 for d in listing:
-                    entry = os.path.join(bindir, d)
+                    entry = os.path.join(libdir, d)
                     if os.path.isdir(entry) and "python" in d:
                         oldpypath = os.environ['PYTHONPATH']
                         newpath = ":".join([oldpypath, os.path.join(entry, "site-packages")])
                         os.environ['PYTHONPATH'] = newpath
                         pypath = True
                         break
+                if not pypath and "lib64" not in libdir:
+                    # try the lib64 location if we aren't already there
+                    libdir = os.path.join(midlog['location'], "lib64")
+                    if os.path.exists(libdir) and os.path.isdir(libdir):
+                        listing = os.listdir(libdir)
+                        for d in listing:
+                            entry = os.path.join(libdir, d)
+                            if os.path.isdir(entry) and "python" in d:
+                                oldpypath = os.environ['PYTHONPATH']
+                                newpath = ":".join([oldpypath, os.path.join(entry, "site-packages")])
+                                os.environ['PYTHONPATH'] = newpath
+                                pypath = True
+                                break
                 # mark that this was done
                 midpath = True
         except KeyError:

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -535,7 +535,20 @@ class TestDef(object):
                 for i,v in enumerate(sublog):
                     self.fill_log_interpolation("%s.%d" % (basestr, i), v)
         else:
-            self.fill_log_interpolation(basestr, str(sublog))
+            # sublog is likely a byte array that might included non-ascii
+            # characters, so protect us in case of an exception
+            try:
+                self.fill_log_interpolation(basestr, str(sublog))
+            except:
+                try:
+                    mystring = sublog.encode('utf-8')
+                    self.fill_log_interpolation(basestr, str(mystring))
+                except:
+                    # replace illegal characters with an asterisk
+                    for i,b in enumerate(sublog):
+                       if not isascii(b):
+                          sublog[i] = '*'
+                    self.fill_log_interpolation(basestr, str(sublog))
 
     def expandWildCards(self, sections):
         expsec = []


### PR DESCRIPTION
**Protect the log interpolation function against utf-8 bytes**
It is possible for programs to output Unicode characters instead
of ASCII. In this case, Python will place the output in a byte
array, but the "str" function will fail when it encounters the
UTF-8 character. Protect against that case - and if even UTF-8
doesn't recognize it, then just replace that character with
an asterisk

**Handle the case of mixed lib builds**
Sometimes the program install will go into the "lib" location,
while the Python install will go into "lib64". Protect against
that case and ensure PYTHONPATH gets correctly set

Signed-off-by: Ralph Castain <rhc@pmix.org>