### PR TITLE
Cleanup setting of PYTHONPATH and ensure PRRTEs don't overlap

### DIFF
--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -196,8 +196,12 @@ class PMIxUnit(TestRunMTTStage):
                 for d in listing:
                     entry = os.path.join(libdir, d)
                     if os.path.isdir(entry) and "python" in d:
-                        oldpypath = os.environ['PYTHONPATH']
-                        newpath = ":".join([oldpypath, os.path.join(entry, "site-packages")])
+                        try:
+                            oldpypath = os.environ['PYTHONPATH']
+                            newpath = ":".join([oldpypath, os.path.join(entry, "site-packages")])
+                        else:
+                            oldpypath = None
+                            newpath = os.path.join(entry, "site-packages")
                         os.environ['PYTHONPATH'] = newpath
                         pypath = True
                         break
@@ -209,8 +213,12 @@ class PMIxUnit(TestRunMTTStage):
                         for d in listing:
                             entry = os.path.join(libdir, d)
                             if os.path.isdir(entry) and "python" in d:
-                                oldpypath = os.environ['PYTHONPATH']
-                                newpath = ":".join([oldpypath, os.path.join(entry, "site-packages")])
+                                try:
+                                    oldpypath = os.environ['PYTHONPATH']
+                                    newpath = ":".join([oldpypath, os.path.join(entry, "site-packages")])
+                                else:
+                                    oldpypath = None
+                                    newpath = os.path.join(entry, "site-packages")
                                 os.environ['PYTHONPATH'] = newpath
                                 pypath = True
                                 break
@@ -327,7 +335,10 @@ class PMIxUnit(TestRunMTTStage):
             os.environ['LD_LIBRARY_PATH'] = oldldlibpath
 
         if pypath:
-            os.environ['PYTHONPATH'] = oldpypath
+            if oldpypath is not None:
+                os.environ['PYTHONPATH'] = oldpypath
+            else:
+                del os.environ['PYTHONPATH']
 
         os.chdir(cwd)
         return

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -77,6 +77,9 @@ class TestDef(object):
         self.log = {}
         self.watchdog = None
         self.plugin_trans_sem = Semaphore()
+        # provide a signature to differentiate this MTT execution
+        # from any other that might be executed in parallel with it
+        self.signature = 0
         # define a few global "constant" names that can be used
         # across plugins - the following categories must match
         # their equivalent values in the server. See
@@ -92,6 +95,7 @@ class TestDef(object):
     def setOptions(self, args):
         self.options = vars(args)
         self.args = args
+        self.signature = os.getpid()
 
     # private function to convert values
     def __convert_value(self, opt, inval):

--- a/pylib/Tools/Fetch/Pip.py
+++ b/pylib/Tools/Fetch/Pip.py
@@ -143,8 +143,11 @@ class Pip(FetchMTTTool):
             for t in results['stdout']:
                 if t.startswith("Location"):
                     log['location'] = t[10:]
-                    # Add the location to PYTHONPATH
-                    pypath = os.environ['PYTHONPATH'] + ":" + log['location']
+                    try:
+                        # Prepend the location to PYTHONPATH if it exists in environ
+                        pypath = ":".join([log['location'], os.environ['PYTHONPATH']])
+                    except:
+                        pypath = log['location']
                     os.environ['PYTHONPATH'] = pypath
                     break
 

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -206,6 +206,12 @@ class PRRTE(LauncherMTTTool):
             self.resetPaths(log, testDef)
             return
 
+        # define a unique rendezvous file for prun to use
+        # to reach the DVM - protects against case where
+        # multiple DVMs are in simultaneous operation
+        pth = "prte.rnd." + str(testDef.signature)
+        os.environ['PMIX_LAUNCHER_RENDEZVOUS_FILE'] = os.path.join(os.getcwd(), pth)
+
         # start the PRRTE DVM
         process = Popen(['prte'], stdout=PIPE, stderr=PIPE)
         # wait a little for the prte daemon to start
@@ -216,6 +222,9 @@ class PRRTE(LauncherMTTTool):
 
         # stop the PRRTE DVM
         results = testDef.execmd.execute(cmds, ["prun", "--terminate"], testDef)
+
+        # cleanup the environ
+        del os.environ['PMIX_LAUNCHER_RENDEZVOUS_FILE']
 
         # Deallocate cluster
         status = self.deallocateCluster(log, cmds, testDef)


### PR DESCRIPTION
Someone might not have PYTHONPATH set in their environment, so protect
against that when setting it. Prepend additions to ensure the proper
site package gets used.

Assign a unique rendezvous file for the DVM to avoid conflicts with
other DVMs running in parallel.

Signed-off-by: Ralph Castain <rhc@pmix.org>