### PR TITLE
Use a different method for timeout detection

### DIFF
--- a/pyclient/debug.ini
+++ b/pyclient/debug.ini
@@ -1,0 +1,108 @@
+#Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+#
+
+# Set defaults
+[MTTDefaults]
+scratch = mttscratch
+description = Run Server/Client test
+platform = Intel Bend
+executor = sequential
+
+# Get the system profile
+[Profile:Installed]
+
+#======================================================================
+# Build PMIx dependencies: libevent, libev, hwloc, and cython
+#======================================================================
+[ASIS MiddlewareGet:libevent]
+plugin = FetchTarball
+url = https://github.com/libevent/libevent/releases/download/release-2.1.10-stable/libevent-2.1.10-stable.tar.gz
+
+[ASIS MiddlewareBuild:libevent]
+parent = MiddlewareGet:libevent
+plugin = Autotools
+
+[ASIS MiddlewareGet:hwloc]
+plugin = FetchTarball
+url = https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.4.tar.bz2
+
+[ASIS MiddlewareBuild:hwloc]
+parent = MiddlewareGet:hwloc
+plugin = Autotools
+
+#======================================================================
+# Build PMIx itself
+#======================================================================
+[ASIS MiddlewareGet:pmix]
+plugin = Git
+url = https://github.com/pmix/pmix
+
+[ASIS MiddlewareBuild:pmix]
+parent = MiddlewareGet:pmix
+plugin = Autotools
+configure_options = --enable-python-bindings --with-devel-headers --disable-visibility
+dependencies = MiddlewareBuild:libevent MiddlewareBuild:hwloc
+autogen_cmd = ./autogen.pl
+stderr_save_lines = 10
+stdout_save_lines = 10
+
+#======================================================================
+# Build PRRTE for testing client APIs
+#======================================================================
+[ASIS MiddlewareGet:PRRTE]
+plugin = Git
+url = https://github.com/pmix/prrte
+
+[ASIS MiddlewareBuild:PRRTE]
+plugin = Autotools
+parent = MiddlewareGet:PRRTE
+
+autogen_cmd = ./autogen.pl
+dependencies = MiddlewareBuild:libevent MiddlewareBuild:hwloc MiddlewareBuild:pmix
+configure_options = --enable-orterun-prefix-by-default --enable-pmix-devel-support
+
+#======================================================================
+# Build the test suite
+#======================================================================
+[ASIS TestGet:PMIxUnit]
+plugin = Git
+url = https://github.com/pmix/pmix-tests
+subdir = unit
+
+[TestBuild:PMIxUnit]
+parent = TestGet:PMIxUnit
+middleware = MiddlewareBuild:PRRTE
+make_envars = CC=pcc
+merge_stdout_stderr = 1
+stderr_save_lines = 100
+
+#======================================================================
+# Run the unit test suite
+#======================================================================
+[TestRun:PMIxUnit]
+plugin = PMIxUnit
+parent = TestBuild:PMIxUnit
+command = ./pmix_test
+timeout = 5
+
+test0 = -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:0]"
+test1 = -n 4 --ns-dist 3:1 --fence "[db | 0:;1:0]"
+test2 = -n 4 --ns-dist 3:1 --fence "[db | 0:;1:]"
+test3 = -n 4 --ns-dist 3:1 --fence "[0:]"
+test4 = -n 4 --ns-dist 3:1 --fence "[b | 0:]"
+test5 = -n 4 --job-fence -c
+test6 = -n 4 --job-fence
+test7 = -n 2 --test-connect
+test8 = -n 5 --test-resolve-peers --ns-dist "1:2:2"
+test9 = -n 5 --test-replace 100:0,1,10,50,99
+test10 = -n 5 --test-internal 10
+test11 = -s 2 -n 2 --job-fence
+test12 = -s 2 -n 2 --job-fence -c
+test13 = -n 2 --test-publish
+test14 = -n 2 --test-spawn
+
+#======================================================================
+# Reporter phase
+#======================================================================
+[Reporter:Console]
+plugin = TextFile

--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -26,6 +26,7 @@ import shlex
 # @param modules_unload  Modules to unload
 # @param modules         Modules to load
 # @param modules_swap    Modules to swap
+# @param timeout         Time limit for application execution
 # @}
 class PMIxUnit(TestRunMTTStage):
 
@@ -39,6 +40,7 @@ class PMIxUnit(TestRunMTTStage):
         self.options['modules'] = (None, "Modules to load")
         self.options['modules_unload'] = (None, "Modules to unload")
         self.options['modules_swap'] = (None, "Modules to swap")
+        self.options['timeout'] = (None, "Time limit for application execution")
 
         self.testDef = None
         self.cmds = None

--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -261,6 +261,7 @@ class PMIxUnit(TestRunMTTStage):
         numTests = 0
         numPass = 0
         numFail = 0
+        numTimed = 0
 
         for test in tests:
             testLog = {'test':test}
@@ -298,15 +299,20 @@ class PMIxUnit(TestRunMTTStage):
 
             results = testDef.execmd.execute(cmds, cmdargs, testDef)
 
-            if 0 == results['status']:
-                numPass = numPass + 1
-                testLog['result'] = testDef.MTT_TEST_PASSED
-            else:
-                numFail = numFail + 1
-                testLog['result'] = testDef.MTT_TEST_FAILED
-                if 0 == finalStatus:
-                    finalStatus = status
-                    finalError = stderr
+            try:
+                if results['timedout']:
+                    numTimed += 1
+                    testLog['result'] = testDef.MTT_TEST_TIMED_OUT
+            except:
+                if 0 == results['status']:
+                    numPass = numPass + 1
+                    testLog['result'] = testDef.MTT_TEST_PASSED
+                else:
+                    numFail = numFail + 1
+                    testLog['result'] = testDef.MTT_TEST_FAILED
+                    if 0 == finalStatus:
+                        finalStatus = status
+                        finalError = stderr
             testLog['status'] = results['status']
             testLog['stdout'] = results['stdout']
             testLog['stderr'] = results['stderr']
@@ -322,6 +328,7 @@ class PMIxUnit(TestRunMTTStage):
         log['numTests'] = numTests
         log['numPass'] = numPass
         log['numFail'] = numFail
+        log['numTimed'] = numTimed
 
         # Revert any requested environment module settings
         status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -213,6 +213,7 @@ class ExecuteCmd(BaseMTTUtility):
 
                     if stdout_done and stderr_done:
                         break
+            p.wait()
             if p.returncode == -15 or p.returncode == -9:
                 testDef.logger.verbose_print("ExecuteCmd Timed Out%s" % (": elapsed=%s"%elapsed_datetime if time_exec else ""), \
                                              timestamp=endtime if time_exec else None)
@@ -235,7 +236,6 @@ class ExecuteCmd(BaseMTTUtility):
             testDef.logger.verbose_print("ExecuteCmd done%s" % (": elapsed=%s"%elapsed_datetime if time_exec else ""), \
                                          timestamp=endtime if time_exec else None)
 
-            p.wait()
             results['status'] = p.returncode
             results['stdout'] = stdout[-1 * stdoutlines:]
             results['stderr'] = stderr[-1 * stderrlines:]

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -16,7 +16,73 @@ import subprocess
 import time
 import datetime
 import signal
+import os, threading, errno
+from contextlib import contextmanager
 from BaseMTTUtility import *
+
+
+class TimeoutThread(object):
+    def __init__(self, seconds):
+        self.seconds = seconds
+        self.cond = threading.Condition()
+        self.cancelled = False
+        self.thread = threading.Thread(target=self._wait)
+
+    def run(self):
+        # start the timer
+        self.thread.start()
+
+    def _wait(self):
+        with self.cond:
+            self.cond.wait(self.seconds)
+
+            if not self.cancelled:
+                self.timed_out()
+
+    def cancel(self):
+        # cancel the timeout, if it hasn't already fired
+        with self.cond:
+            self.cancelled = True
+            self.cond.notify()
+        self.thread.join()
+
+    def timed_out(self):
+        # raise exception to signal timeout
+        raise NotImplementedError
+
+class KillProcessThread(TimeoutThread):
+    def __init__(self, seconds, pid):
+        super(KillProcessThread, self).__init__(seconds)
+        self.pid = pid
+
+    def timed_out(self):
+        # be polite and provide a SIGTERM to let them
+        # exit cleanly
+        try:
+            os.kill(self.pid, signal.SIGTERM)
+        except OSError as e:
+            # if it is already gone, then ignore the
+            # error - just a race condition
+            if e.errno not in (errno.EPERM, errno. ESRCH):
+                raise e
+        # wait a little bit
+        time.sleep(1)
+        # hammer it with a cannonball
+        try:
+            os.kill(self.pid, signal.SIGKILL)
+        except OSError as e:
+            # If the process is already gone, ignore the error.
+            if e.errno not in (errno.EPERM, errno. ESRCH):
+                raise e
+
+@contextmanager
+def processTimeout(seconds, pid):
+    timeout = KillProcessThread(seconds, pid)
+    timeout.run()
+    try:
+        yield
+    finally:
+        timeout.cancel()
 
 
 ## @addtogroup Utilities
@@ -112,10 +178,11 @@ class ExecuteCmd(BaseMTTUtility):
             # output as the process runs
             p = subprocess.Popen(mycmdargs,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            try:
-                if options is not None and 'timeout' in options:
-                    t = int(options['timeout'])
-                    p.wait(timeout=t)
+            if options is not None and 'timeout' in options and options['timeout'] is not None:
+                t = int(options['timeout'])
+            else:
+                t = 100000000
+            with processTimeout(t, p.pid):
                 # loop until the pipes close
                 while True:
                     reads = [p.stdout.fileno(), p.stderr.fileno()]
@@ -146,12 +213,12 @@ class ExecuteCmd(BaseMTTUtility):
 
                     if stdout_done and stderr_done:
                         break
-            except subprocess.TimeoutExpired:
+            if p.returncode == -15 or p.returncode == -9:
                 testDef.logger.verbose_print("ExecuteCmd Timed Out%s" % (": elapsed=%s"%elapsed_datetime if time_exec else ""), \
                                              timestamp=endtime if time_exec else None)
                 stderr.append("**** TIMED OUT ****")
                 results['timedout'] = True
-                results['status'] = 1
+                results['status'] = p.returncode
                 results['stdout'] = stdout[-1 * stdoutlines:]
                 results['stderr'] = stderr[-1 * stderrlines:]
                 if time_exec:


### PR DESCRIPTION
Apparently, Python 2 does not have the subprocess "timeout" feature in
it. One solution would be to have everyone install the subprocess32
module that backported such features to Python 2, but that would be
intrusive. So instead use a threaded model for tracking timeout.

Little more cumbersome and involves another thread, but appears to be
working just fine under test.

Fixes #837 

Signed-off-by: Ralph Castain <rhc@pmix.org>