### PR TITLE
Correctly set the return result so the IUDatabase reporter can report it

### DIFF
--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -296,6 +296,7 @@ class Autotools(BuildMTTTool):
                     log['status'] = results['status']
                     log['stdout'] = results['stdout']
                     log['stderr'] = results['stderr']
+                    log['result'] = testDef.MTT_TEST_FAILED
 
                     # Revert any requested environment module settings
                     status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -339,11 +340,13 @@ class Autotools(BuildMTTTool):
                             # we cannot do what the user requested
                             log['status'] = 1
                             log['stderr'] = "Location of dependency " + d + " could not be found"
+                            log['result'] = testDef.MTT_TEST_FAILED
                             return
                     except:
                         # we don't have a record of this dependency
                         log['status'] = 1
                         log['stderr'] = "Log for dependency " + d + " could not be found"
+                            log['result'] = testDef.MTT_TEST_FAILED
                         return
                     # split the dependency string to get the package name
                     try:
@@ -351,6 +354,7 @@ class Autotools(BuildMTTTool):
                     except:
                         log['status'] = 1
                         log['stderr'] = "Dependency " + d + " is missing package name"
+                        log['result'] = testDef.MTT_TEST_FAILED
                         return
                     # add the location and dependency option
                     opt = "--with-{0}".format(pkg[1]) + "={0}".format(loc)
@@ -383,6 +387,7 @@ class Autotools(BuildMTTTool):
                 log['status'] = results['status']
                 log['stdout'] = results['stdout']
                 log['stderr'] = results['stderr']
+                log['result'] = testDef.MTT_TEST_FAILED
 
                 # Revert any requested environment module settings
                 status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -434,6 +439,7 @@ class Autotools(BuildMTTTool):
             log['status'] = results['status']
             log['stdout'] = results['stdout']
             log['stderr'] = results['stderr']
+            log['result'] = testDef.MTT_TEST_FAILED
 
             # Revert any requested environment module settings
             status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -466,6 +472,7 @@ class Autotools(BuildMTTTool):
             log['status'] = results['status']
             log['stdout'] = results['stdout']
             log['stderr'] = results['stderr']
+            log['result'] = testDef.MTT_TEST_FAILED
 
             # Revert any requested environment module settings
             status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)
@@ -500,6 +507,10 @@ class Autotools(BuildMTTTool):
         log['status'] = results['status']
         log['stdout'] = results['stdout']
         log['stderr'] = results['stderr']
+        if 0 != results['status']:
+            log['result'] = testDef.MTT_TEST_FAILED
+        else:
+            log['result'] = testDef.MTT_TEST_PASSED
 
         # Revert any requested environment module settings
         status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -346,7 +346,7 @@ class Autotools(BuildMTTTool):
                         # we don't have a record of this dependency
                         log['status'] = 1
                         log['stderr'] = "Log for dependency " + d + " could not be found"
-                            log['result'] = testDef.MTT_TEST_FAILED
+                        log['result'] = testDef.MTT_TEST_FAILED
                         return
                     # split the dependency string to get the package name
                     try:

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -146,10 +146,12 @@ class Shell(BuildMTTTool):
                 if parentlog is None:
                     log['status'] = 1
                     log['stderr'] = "Parent",cmds['parent'],"log not found"
+                    log['result'] = testDef.MTT_TEST_FAILED
                     return
         except KeyError:
             log['status'] = 1
             log['stderr'] = "Parent not specified"
+            log['result'] = testDef.MTT_TEST_FAILED
             return
         try:
             parentloc = os.path.join(os.getcwd(), testDef.options['scratchdir'])
@@ -157,6 +159,7 @@ class Shell(BuildMTTTool):
         except KeyError:
             log['status'] = 1
             log['stderr'] = "No scratch directory in log"
+            log['result'] = testDef.MTT_TEST_FAILED
             return
         if parentlog is not None:
             try:
@@ -165,6 +168,7 @@ class Shell(BuildMTTTool):
             except KeyError:
                 log['status'] = 1
                 log['stderr'] = "Location of package to build was not specified in parent stage"
+                log['result'] = testDef.MTT_TEST_FAILED
                 return
         else:
             try:
@@ -173,6 +177,7 @@ class Shell(BuildMTTTool):
             except KeyError:
                 log['status'] = 1
                 log['stderr'] = "No section in log"
+                log['result'] = testDef.MTT_TEST_FAILED
                 return
         # check to see if this is a dryrun
         if testDef.options['dryrun']:
@@ -188,6 +193,7 @@ class Shell(BuildMTTTool):
                         testDef.logger.verbose_print("asis_target " + os.path.join(parentloc,cmds['asis_target']) + " exists. Skipping...")
                         log['location'] = location
                         log['status'] = 0
+                        log['result'] = testDef.MTT_TEST_PASSED
                         return
                     else:
                         testDef.logger.verbose_print("asis_target " + os.path.join(parentloc,cmds['asis_target']) + " does not exist. Continuing...")
@@ -196,6 +202,7 @@ class Shell(BuildMTTTool):
                         testDef.logger.verbose_print("directory " + location + " exists. Skipping...")
                         log['location'] = location
                         log['status'] = 0
+                        log['result'] = testDef.MTT_TEST_PASSED
                         return
                     else:
                         testDef.logger.verbose_print("directory " + location + " does not exist. Continuing...")
@@ -362,6 +369,7 @@ class Shell(BuildMTTTool):
                 log['status'] = results['status']
             log['stdout'] = results['stdout']
             log['stderr'] = results['stderr']
+            log['result'] = testDef.MTT_TEST_PASSED
             try:
                 log['time'] = results['elapsed_secs']
             except:
@@ -377,6 +385,7 @@ class Shell(BuildMTTTool):
             log['stderr'] = results['stderr']
         # record this location for any follow-on steps
         log['location'] = location
+        log['result'] = testDef.MTT_TEST_PASSED
 
         # Revert any requested environment module settings
         status,stdout,stderr = testDef.modcmd.revertModules(log['section'], testDef)

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -183,6 +183,7 @@ class Shell(BuildMTTTool):
         if testDef.options['dryrun']:
             # just log success and return
             log['status'] = 0
+            log['result'] = testDef.MTT_TEST_PASSED
             return
 
         # Check to see if this needs to be ran if ASIS is specified
@@ -276,6 +277,7 @@ class Shell(BuildMTTTool):
                         log['status'] = status
                         log['stdout'] = stdout
                         log['stderr'] = stderr
+                        log['result'] = testDef.MTT_TEST_FAILED
                         return
         except KeyError:
             pass
@@ -286,6 +288,7 @@ class Shell(BuildMTTTool):
             log['status'] = status
             log['stdout'] = stdout
             log['stderr'] = stderr
+            log['result'] = testDef.MTT_TEST_FAILED
             return
 
         # sense and record the compiler being used
@@ -355,8 +358,7 @@ class Shell(BuildMTTTool):
             testDef.harasser.stop(harass_exec_ids, testDef)
 
         # Deallocate cluster
-        if False == self.deallocate(log, cmds, testDef):
-            return
+        self.deallocate(log, cmds, testDef)
 
         if (cmds['fail_test'] is None and 0 != results['status']) \
                 or (cmds['fail_test'] is not None and cmds['fail_returncode'] is None and 0 == results['status']) \
@@ -369,7 +371,7 @@ class Shell(BuildMTTTool):
                 log['status'] = results['status']
             log['stdout'] = results['stdout']
             log['stderr'] = results['stderr']
-            log['result'] = testDef.MTT_TEST_PASSED
+            log['result'] = testDef.MTT_TEST_FAILED
             try:
                 log['time'] = results['elapsed_secs']
             except:
@@ -393,7 +395,7 @@ class Shell(BuildMTTTool):
             log['status'] = status
             log['stdout'] = stdout
             log['stderr'] = stderr
-            return
+            # the tests still passed, so leave it logged that way
 
         # if we added middleware to the paths, remove it
         if midpath:


### PR DESCRIPTION
The IUDatabase reporter needs slightly different information to
correctly set the result codes in the MTT database. You need to set the
'results' entry in the log to one of the predefined values. I have tried
to hit the right spots in these two commonly used plugins, but someone
will need to validate that I got them and fill in any that are missing.

Fixes #845

Signed-off-by: Ralph Castain <rhc@pmix.org>