### PR TITLE
Be more flexible in how we take input

### DIFF
--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -28,7 +28,6 @@ import shlex
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
 # @param fail_tests                Names of tests that are expected to fail
-# @param fail_returncodes          Expected returncodes of tests expected to fail
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -56,7 +55,6 @@ class ALPS(LauncherMTTTool):
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
         self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
-        self.options['fail_returncodes'] = (None, "Expected return code of tests expected to fail")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -27,7 +27,7 @@ import shlex
 # @param stdout_save_lines         Number of lines of stdout to save
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
-# @param fail_tests                Names of tests that are expected to fail
+# @param fail_tests                Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -54,7 +54,7 @@ class ALPS(LauncherMTTTool):
         self.options['stdout_save_lines'] = (-1, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
-        self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
+        self.options['fail_tests'] = (None, "Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -31,7 +31,7 @@ import shlex
 # @param stdout_save_lines         Number of lines of stdout to save
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
-# @param fail_tests                Names of tests that are expected to fail
+# @param fail_tests                Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -60,7 +60,7 @@ class OpenMPI(LauncherMTTTool):
         self.options['stdout_save_lines'] = (-1, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
-        self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
+        self.options['fail_tests'] = (None, "Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -32,7 +32,6 @@ import shlex
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
 # @param fail_tests                Names of tests that are expected to fail
-# @param fail_returncodes          Expected return codes of tests expected to fail
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -62,7 +61,6 @@ class OpenMPI(LauncherMTTTool):
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
         self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
-        self.options['fail_returncodes'] = (None, "Expected returncodes of tests expected to fail")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -32,7 +32,7 @@ from subprocess import Popen, PIPE
 # @param stdout_save_lines         Number of lines of stdout to save
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
-# @param fail_tests                Names of tests that are expected to fail
+# @param fail_tests                Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -62,7 +62,7 @@ class PRRTE(LauncherMTTTool):
         self.options['stdout_save_lines'] = (-1, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
-        self.options['fail_tests'] = (None, "Comma-delimited names of tests that are expected to fail")
+        self.options['fail_tests'] = (None, "Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Comma-delimited names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -33,7 +33,6 @@ from subprocess import Popen, PIPE
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
 # @param fail_tests                Names of tests that are expected to fail
-# @param fail_returncodes          Expected return codes of tests expected to fail
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -64,7 +63,6 @@ class PRRTE(LauncherMTTTool):
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
         self.options['fail_tests'] = (None, "Comma-delimited names of tests that are expected to fail")
-        self.options['fail_returncodes'] = (None, "Comma-delimited expected returncodes of tests expected to fail")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Comma-delimited names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -29,7 +29,7 @@ import subprocess
 # @param stdout_save_lines         Number of lines of stdout to save
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
-# @param fail_tests                Names of tests that are expected to fail
+# @param fail_tests                Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -58,7 +58,7 @@ class SLURM(LauncherMTTTool):
         self.options['stdout_save_lines'] = (-1, "Number of lines of stdout to save")
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
-        self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
+        self.options['fail_tests'] = (None, "Names of tests that are expected to fail. Can use space or comma between entries. Include the expected return code using the following format: test_name:#")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -30,7 +30,6 @@ import subprocess
 # @param stderr_save_lines         Number of lines of stderr to save
 # @param test_dir                  Names of directories to be scanned for tests
 # @param fail_tests                Names of tests that are expected to fail
-# @param fail_returncodes          Expected returncodes of tests expected to fail
 # @param fail_timeout              Maximum execution time for tests expected to fail
 # @param skip_tests                Names of tests to be skipped
 # @param max_num_tests             Maximum number of tests to run
@@ -60,7 +59,6 @@ class SLURM(LauncherMTTTool):
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save")
         self.options['test_dir'] = (None, "Names of directories to be scanned for tests")
         self.options['fail_tests'] = (None, "Names of tests that are expected to fail")
-        self.options['fail_returncodes'] = (None, "Expected return code of tests expected to fail")
         self.options['fail_timeout'] = (None, "Maximum execution time for tests expected to fail")
         self.options['skip_tests'] = (None, "Names of tests to be skipped")
         self.options['max_num_tests'] = (None, "Maximum number of tests to run")


### PR DESCRIPTION
Accept lists of tests expected to fail and tests to skip that are
delimited by commas, spaces, or tabs. Instead of having a separate list
of expected return codes for failed tests, specify those in the same
place where we list those tests:

fail_tests = ftest1:3 ftest2 ftest3:-5

where we specify the expected return code with a ":code" suffix to the
name of the test. Tests without an expected return code will be marked
as "passed" if they fail regardless of what they return.

Add a "dryrun" option to the IUDatabase reporter so we can see what it
would have sent without actually sending anything to the db.

Refs #852 

Signed-off-by: Ralph Castain <rhc@pmix.org>