### PR TITLE
ELK-friendly log output

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -144,6 +144,9 @@ debugGroup.add_argument("--verbose",
 debugGroup.add_argument("--extraverbose",
                       action="store_true", dest="extraverbose", default=False,
                       help="Output timestamps with every verbose message")
+debugGroup.add_argument("--elk",
+                        dest="elk", default=None,
+                        help="Output json, which is more easily parsible by ELK. Pass in execution id or other identifying string")
 debugGroup.add_argument("--dryrun",
                       action="store_true", dest="dryrun", default=False,
                       help="Show commands, but do not execute them")

--- a/pylib/Stages/Firmware/FooFlash.py
+++ b/pylib/Stages/Firmware/FooFlash.py
@@ -39,7 +39,7 @@ class FooFlash(FirmwareMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
 
     def execute(self, log, keyvals, testDef):
         # execute whatever commands are provided, recording

--- a/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
+++ b/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
@@ -63,7 +63,7 @@ class DefaultMTTDefaults(MTTDefaultsMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def priority(self):

--- a/pylib/Stages/Profile/CheckProfile.py
+++ b/pylib/Stages/Profile/CheckProfile.py
@@ -63,7 +63,7 @@ class CheckProfile(ProfileMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            self.testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Stages/Profile/DefaultProfile.py
+++ b/pylib/Stages/Profile/DefaultProfile.py
@@ -54,7 +54,7 @@ class DefaultProfile(ProfileMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            self.testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Stages/Provisioning/WWulf3.py
+++ b/pylib/Stages/Provisioning/WWulf3.py
@@ -69,7 +69,7 @@ class WWulf3(ProvisionMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def allocate(self, log, cmds, testDef):

--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -79,11 +79,12 @@ class IUDatabase(ReporterMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):
         # parse the provided keyvals against our options
+        self.testDef = testDef
         testDef.parseOptions(log, self.options, keyvals, self.cmds)
         if self.cmds['dryrun']:
             self.cmds['debug_screen'] = True
@@ -132,7 +133,7 @@ class IUDatabase(ReporterMTTStage):
         if not self.cmds['dryrun']:
             client_serial = self._get_client_serial(s, self.cmds['url'], www_auth)
             if client_serial < 0:
-                print("Error: Unable to get a client serial (rtn=%d)" % (client_serial))
+                self.testDef.logger.print("Error: Unable to get a client serial (rtn=%d)" % (client_serial))
 
         headers = {}
         headers['content-type'] = 'application/json'
@@ -172,11 +173,11 @@ class IUDatabase(ReporterMTTStage):
         try:
             pp = pprint.PrettyPrinter(indent=4)
             if self.cmds['debug_screen']:
-                print("<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>")
+                self.testDef.logger.print("<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>")
                 for lg in fullLog:
-                    print("----------------- Section (%s) " % (lg['section']))
+                    self.testDef.logger.print("----------------- Section (%s) " % (lg['section']))
                     pp.pprint(lg)
-                print("<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>")
+                self.testDef.logger.print("<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>>")
         except:
             pass;
 
@@ -199,7 +200,7 @@ class IUDatabase(ReporterMTTStage):
     def _submit_test_run(self, logger, lg, metadata, s, url, testDef, httpauth=None):
         try:
             if self.cmds['debug_screen']:
-                print("----------------- Test Run (%s) " % (lg['section']))
+                self.testDef.logger.print("----------------- Test Run (%s) " % (lg['section']))
                 pp = pprint.PrettyPrinter(indent=4)
                 pp.pprint(lg)
         except:
@@ -471,7 +472,7 @@ class IUDatabase(ReporterMTTStage):
     def _submit_test_build(self, logger, lg, metadata, s, url, httpauth=None):
         try:
             if self.cmds['debug_screen']:
-                print("----------------- Test Build (%s) " % (lg['section']))
+                self.testDef.logger.print("----------------- Test Build (%s) " % (lg['section']))
                 pp = pprint.PrettyPrinter(indent=4)
                 pp.pprint(lg)
         except:
@@ -629,7 +630,7 @@ class IUDatabase(ReporterMTTStage):
 
         try:
             if self.cmds['debug_screen']:
-                print("----------------- MPI Install (%s) " % (lg['section']))
+                self.testDef.logger.print("----------------- MPI Install (%s) " % (lg['section']))
                 pp = pprint.PrettyPrinter(indent=4)
                 pp.pprint(lg)
         except:
@@ -650,7 +651,7 @@ class IUDatabase(ReporterMTTStage):
 
         profile = logger.getLog('Profile:Installed')['profile']
         if profile is None:
-            print("Error: Failed to get 'profile'")
+            self.testDef.logger.print("Error: Failed to get 'profile'")
             return None
 
         #
@@ -829,9 +830,9 @@ class IUDatabase(ReporterMTTStage):
 
         try:
             if self.cmds['debug_screen']:
-                print("<<<<<<<---------------- Payload (Start) -------------------------->>>>>>")
-                print(json.dumps(payload, sort_keys=True, indent=4, separators=(',',': ')))
-                print("<<<<<<<---------------- Payload (End  ) -------------------------->>>>>>")
+                self.testDef.logger.print("<<<<<<<---------------- Payload (Start) -------------------------->>>>>>")
+                self.testDef.logger.print(json.dumps(payload, sort_keys=True, indent=4, separators=(',',': ')))
+                self.testDef.logger.print("<<<<<<<---------------- Payload (End  ) -------------------------->>>>>>")
                 if self.cmds['dryrun']:
                     return None
         except:
@@ -845,13 +846,13 @@ class IUDatabase(ReporterMTTStage):
 
         try:
             if self.cmds['debug_screen']:
-                print("<<<<<<<---------------- Response -------------------------->>>>>>")
-                print("Result: %d: %s" % (r.status_code, r.headers['content-type']))
-                print(r.headers)
-                print(r.reason)
-                print("<<<<<<<---------------- Raw Output (Start) ---------------->>>>>>")
-                print(r.text)
-                print("<<<<<<<---------------- Raw Output (End  ) ---------------->>>>>>")
+                self.testDef.logger.print("<<<<<<<---------------- Response -------------------------->>>>>>")
+                self.testDef.logger.print("Result: %d: %s" % (r.status_code, r.headers['content-type']))
+                self.testDef.logger.print(r.headers)
+                self.testDef.logger.print(r.reason)
+                self.testDef.logger.print("<<<<<<<---------------- Raw Output (Start) ---------------->>>>>>")
+                self.testDef.logger.print(r.text)
+                self.testDef.logger.print("<<<<<<<---------------- Raw Output (End  ) ---------------->>>>>>")
         except:
             pass
 
@@ -863,13 +864,13 @@ class IUDatabase(ReporterMTTStage):
     def _extract_param(self, logger, section, parameter):
         found = logger.getLog(section)
         if found is None:
-            print("_extract_param: Section (%s) Not Found! [param=%s]" % (section, parameter))
+            self.testDef.logger.print("_extract_param: Section (%s) Not Found! [param=%s]" % (section, parameter))
             return None
 
         try:
             params = found['parameters']
         except KeyError:
-            print("_extract_param: Section (%s) did not contain a parameters entry! [param=%s]" % (section, parameter))
+            self.testDef.logger.print("_extract_param: Section (%s) did not contain a parameters entry! [param=%s]" % (section, parameter))
             return None
         for p in params:
             if p[0] == parameter:

--- a/pylib/Stages/Reporter/JunitXML.py
+++ b/pylib/Stages/Reporter/JunitXML.py
@@ -48,7 +48,7 @@ class JunitXML(ReporterMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):
@@ -96,7 +96,7 @@ class JunitXML(ReporterMTTStage):
         # TODO:  Pull in the resource manager jobid.
         jobid = "job1"
         ts = TestSuite(jobid, testCases)
-        print(TestSuite.to_xml_string([ts]), file=self.fh)
+        testDef.logger.print(TestSuite.to_xml_string([ts]), file=self.fh)
 
         if cmds['filename'] is not None:
             self.fh.close()

--- a/pylib/Stages/TestBuild/DefaultTestBuild.py
+++ b/pylib/Stages/TestBuild/DefaultTestBuild.py
@@ -61,7 +61,7 @@ class DefaultTestBuild(TestBuildMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Stages/TestRun/PMIxUnit.py
+++ b/pylib/Stages/TestRun/PMIxUnit.py
@@ -67,7 +67,7 @@ class PMIxUnit(TestRunMTTStage):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/System/LoadClasses.py
+++ b/pylib/System/LoadClasses.py
@@ -43,7 +43,7 @@ class LoadClasses(object):
                 # Python 2 requires string cast
                 m = imp.load_source(modname, str(filename))
             except ImportError:
-                print("ERROR: unable to load " + modname + " from file " + str(filename))
+                testDef.logger.print("ERROR: unable to load " + modname + " from file " + str(filename))
                 exit(1)
             # add the class to the corresponding category
             try:

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -121,7 +121,7 @@ class TestDef(object):
                     return 0, False
             else:
                 # unknown conversion required
-                print("Unknown conversion required for " + inval)
+                self.logger.print("Unknown conversion required for " + inval)
                 return 1, None
         elif type(opt) is int:
             if type(inval) is int:
@@ -130,7 +130,7 @@ class TestDef(object):
                 return 0, int(inval)
             else:
                 # unknown conversion required
-                print("Unknown conversion required for " + inval)
+                self.logger.print("Unknown conversion required for " + inval)
                 return 1, None
         elif type(opt) is float:
             if type(inval) is float:
@@ -139,7 +139,7 @@ class TestDef(object):
                 return 0, float(inval)
             else:
                 # unknown conversion required
-                print("Unknown conversion required for " + inval)
+                self.logger.print("Unknown conversion required for " + inval)
                 return 1, None
         else:
             return 1, None
@@ -247,7 +247,7 @@ class TestDef(object):
 
     def loadPlugins(self, basedir, topdir):
         if self.loaded:
-            print("Cannot load plugins multiple times")
+            self.logger.print("Cannot load plugins multiple times")
             sys.exit(1)
         self.loaded = True
 
@@ -255,7 +255,7 @@ class TestDef(object):
         try:
             m = imp.load_source("LoadClasses", os.path.join(basedir, "LoadClasses.py"));
         except ImportError:
-            print("ERROR: unable to load LoadClasses that must contain the class loader object")
+            self.logger.print("ERROR: unable to load LoadClasses that must contain the class loader object")
             sys.exit(1)
         cls = getattr(m, "LoadClasses")
         a = cls()
@@ -279,13 +279,13 @@ class TestDef(object):
         # Load plugins from each of the specified plugin dirs
         for dirPath in plugindirs:
             if not Path(dirPath).exists():
-                print("Attempted to load plugins from non-existent path:", dirPath)
+                self.logger.print("Attempted to load plugins from non-existent path: %s" % dirPath)
                 continue
             try:
                 self.loader.load(dirPath)
             except Exception as e:
-                print("Exception caught while loading plugins:")
-                print(e)
+                self.logger.print("Exception caught while loading plugins:")
+                self.logger.print(e)
                 sys.exit(1)
 
         # Build plugin managers,
@@ -346,9 +346,9 @@ class TestDef(object):
                 if self.execmd is not None and self.modcmd is not None and self.watchdog is not None:
                     break
         if self.execmd is None:
-            print("ExecuteCmd plugin was not found")
-            print("This is a basic capability required")
-            print("for MTT operations - cannot continue")
+            self.logger.print("ExecuteCmd plugin was not found")
+            self.logger.print("This is a basic capability required")
+            self.logger.print("for MTT operations - cannot continue")
             sys.exit(1)
         # Configure harasser plugin
         for pluginInfo in self.tools.getPluginsOfCategory("Harasser"):
@@ -356,9 +356,9 @@ class TestDef(object):
                 self.harasser = pluginInfo.plugin_object
                 break
         if self.harasser is None:
-            print("Harasser plugin was not found")
-            print("This is required for all TestRun plugins")
-            print("cannot continue")
+            self.logger.print("Harasser plugin was not found")
+            self.logger.print("This is required for all TestRun plugins")
+            self.logger.print("cannot continue")
             sys.exit(1)
         # similarly, capture the highest priority defaults stage here
         pri = -1
@@ -372,10 +372,10 @@ class TestDef(object):
     def printInfo(self):
         # Print the available MTT sections out, if requested
         if self.options['listsections']:
-            print("Supported MTT stages:")
+            self.logger.print("Supported MTT stages:")
             # print them in the default order of execution
             for stage in self.loader.stageOrder:
-                print("    " + stage)
+                self.logger.print("    " + stage)
             sys.exit(0)
 
         # Print the detected plugins for a given stage
@@ -385,15 +385,15 @@ class TestDef(object):
                 sections = self.loader.stageOrder
             else:
                 sections = self.options['listplugins'].split(',')
-            print()
+            self.logger.print()
             for section in sections:
-                print(section + ":")
+                self.logger.print(section + ":")
                 try:
                     for pluginInfo in self.stages.getPluginsOfCategory(section):
-                        print("    " + pluginInfo.plugin_object.print_name())
+                        self.logger.print("    " + pluginInfo.plugin_object.print_name())
                 except KeyError:
-                    print("    Invalid stage name " + section)
-                print()
+                    self.logger.print("    Invalid stage name " + section)
+                self.logger.print()
             sys.exit(1)
 
         # Print the options for a given plugin
@@ -403,43 +403,43 @@ class TestDef(object):
                 sections = self.loader.stageOrder
             else:
                 sections = self.options['liststageoptions'].split(',')
-            print()
+            self.logger.print()
             for section in sections:
-                print(section + ":")
+                self.logger.print(section + ":")
                 try:
                     for pluginInfo in self.stages.getPluginsOfCategory(section):
-                        print("    " + pluginInfo.plugin_object.print_name() + ":")
+                        self.logger.print("    " + pluginInfo.plugin_object.print_name() + ":")
                         pluginInfo.plugin_object.print_options(self, "        ")
                 except KeyError:
-                    print("    Invalid stage name " + section)
-                print()
+                    self.logger.print("    Invalid stage name " + section)
+                self.logger.print()
             sys.exit(1)
 
         # Print the available MTT tools out, if requested
         if self.options['listtools']:
-            print("Available MTT tools:")
+            self.logger.print("Available MTT tools:")
             availTools = list(self.loader.tools.keys())
             for tool in availTools:
-                print("    " + tool)
+                self.logger.print("    " + tool)
             sys.exit(0)
 
         # Print the detected tool plugins for a given tool type
         if self.options['listtoolmodules']:
             # if the list is '*', print the plugins for every type
             if self.options['listtoolmodules'] == "*":
-                print()
+                self.logger.print()
                 availTools = list(self.loader.tools.keys())
             else:
                 availTools = self.options['listtoolmodules'].split(',')
-            print()
+            self.logger.print()
             for tool in availTools:
-                print(tool + ":")
+                self.logger.print(tool + ":")
                 try:
                     for pluginInfo in self.tools.getPluginsOfCategory(tool):
-                        print("    " + pluginInfo.plugin_object.print_name())
+                        self.logger.print("    " + pluginInfo.plugin_object.print_name())
                 except KeyError:
-                    print("    Invalid tool type name",tool)
-                print()
+                    self.logger.print("    Invalid tool type name %s" % tool)
+                self.logger.print()
             sys.exit(1)
 
         # Print the options for a given plugin
@@ -449,43 +449,43 @@ class TestDef(object):
                 availTools = list(self.loader.tools.keys())
             else:
                 availTools = self.options['listtooloptions'].split(',')
-            print()
+            self.logger.print()
             for tool in availTools:
-                print(tool + ":")
+                self.logger.print(tool + ":")
                 try:
                     for pluginInfo in self.tools.getPluginsOfCategory(tool):
-                        print("    " + pluginInfo.plugin_object.print_name() + ":")
+                        self.logger.print("    " + pluginInfo.plugin_object.print_name() + ":")
                         pluginInfo.plugin_object.print_options(self, "        ")
                 except KeyError:
-                    print("    Invalid tool type name " + tool)
-                print()
+                    self.logger.print("    Invalid tool type name " + tool)
+                self.logger.print()
             sys.exit(1)
 
         # Print the available MTT utilities out, if requested
         if self.options['listutils']:
-            print("Available MTT utilities:")
+            self.logger.print("Available MTT utilities:")
             availUtils = list(self.loader.utilities.keys())
             for util in availUtils:
-                print("    " + util)
+                self.logger.print("    " + util)
             sys.exit(0)
 
         # Print the detected utility plugins for a given tool type
         if self.options['listutilmodules']:
             # if the list is '*', print the plugins for every type
             if self.options['listutilmodules'] == "*":
-                print()
+                self.logger.print()
                 availUtils = list(self.loader.utilities.keys())
             else:
                 availUtils = self.options['listutilitymodules'].split(',')
-            print()
+            self.logger.print()
             for util in availUtils:
-                print(util + ":")
+                self.logger.print(util + ":")
                 try:
                     for pluginInfo in self.utilities.getPluginsOfCategory(util):
-                        print("    " + pluginInfo.plugin_object.print_name())
+                        self.logger.print("    " + pluginInfo.plugin_object.print_name())
                 except KeyError:
-                    print("    Invalid utility type name")
-                print()
+                    self.logger.print("    Invalid utility type name")
+                self.logger.print()
             sys.exit(1)
 
         # Print the options for a given plugin
@@ -495,24 +495,24 @@ class TestDef(object):
                 availUtils = list(self.loader.utilities.keys())
             else:
                 availUtils = self.options['listutiloptions'].split(',')
-            print()
+            self.logger.print()
             for util in availUtils:
-                print(util + ":")
+                self.logger.print(util + ":")
                 try:
                     for pluginInfo in self.utilities.getPluginsOfCategory(util):
-                        print("    " + pluginInfo.plugin_object.print_name() + ":")
+                        self.logger.print("    " + pluginInfo.plugin_object.print_name() + ":")
                         pluginInfo.plugin_object.print_options(self, "        ")
                 except KeyError:
-                    print("    Invalid utility type name " + util)
-                print()
+                    self.logger.print("    Invalid utility type name " + util)
+                self.logger.print()
             sys.exit(1)
 
 
         # if they asked for the version info, print it and exit
         if self.options['version']:
             for pluginInfo in self.tools.getPluginsOfCategory("Version"):
-                print("MTT Base:   " + pluginInfo.plugin_object.getVersion())
-                print("MTT Client: " + pluginInfo.plugin_object.getClientVersion())
+                self.logger.print("MTT Base:   " + pluginInfo.plugin_object.getVersion())
+                self.logger.print("MTT Client: " + pluginInfo.plugin_object.getClientVersion())
             sys.exit(0)
 
     def openLogger(self):
@@ -620,10 +620,10 @@ class TestDef(object):
                                              for l in file_contents.split("\n") \
                                              if sum(["${ENV:%s}"%e in l for e in env_not_found])])
         if lines_with_env_not_found:
-            print("ERROR: Not all required environment variables are defined.")
-            print("ERROR: Still need:")
+            self.logger.print("ERROR: Not all required environment variables are defined.")
+            self.logger.print("ERROR: Still need:")
             for l in lines_with_env_not_found:
-                print("ERROR: %s"%l)
+                self.logger.print("ERROR: %s"%l)
             sys.exit(1)
 
     def configTest(self):
@@ -656,7 +656,7 @@ class TestDef(object):
         # cycle thru the input files
         for testFile in self.log['inifiles']:
             if not os.path.isfile(testFile):
-                print("Test description file",testFile,"not found!")
+                self.logger.print("Test description file %s not found!" % testFile)
                 sys.exit(1)
             self.config.read(self.log['inifiles'])
 
@@ -705,7 +705,7 @@ class TestDef(object):
                 self.actives.append(section)
 
         if sections is not None and 0 != len(sections) and not skip:
-            print("ERROR: sections were specified for execution and not found:",sections)
+            self.logger.print("ERROR: sections were specified for execution and not found: %s" % sections)
             sys.exit(1)
 
         # set Defaults -command line args supercede .ini args
@@ -754,13 +754,13 @@ class TestDef(object):
         self.logger.print_cmdline_args(self)
 
         if not self.loaded:
-            print("Plugins have not been loaded - cannot execute test")
+            self.logger.print("Plugins have not been loaded - cannot execute test")
             sys.exit(1)
         if self.config is None:
-            print("No test definition file was parsed - cannot execute test")
+            self.logger.print("No test definition file was parsed - cannot execute test")
             sys.exit(1)
         if not self.tools.getPluginByName(executor, "Executor"):
-            print("Specified executor %s not found" % executor)
+            self.logger.print("Specified executor %s not found" % executor)
             sys.exit(1)
         # activate the specified plugin
         self.tools.activatePluginByName(executor, "Executor")
@@ -891,5 +891,5 @@ class TestDef(object):
             except:
                 return None
         else:
-            print("Unrecognized category:",category)
+            self.logger.print("Unrecognized category: %s" % category)
             return None

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -81,7 +81,7 @@ class Autotools(BuildMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):
@@ -589,7 +589,7 @@ class Autotools(BuildMTTTool):
             confirmation = os.path.join(pfx, 'build_complete')
             fo = open(confirmation, 'w')
             fo.write("Build was successful")
-            print("BUILD SUCCESSFUL FILE CREATED AT: " + confirmation)
+            testDef.logger.print("BUILD SUCCESSFUL FILE CREATED AT: " + confirmation)
             fo.close()
         except:
             pass

--- a/pylib/Tools/Build/Hostfile.py
+++ b/pylib/Tools/Build/Hostfile.py
@@ -59,7 +59,7 @@ class Hostfile(BuildMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -81,7 +81,7 @@ class Shell(BuildMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def allocate(self, log, cmds, testDef):
@@ -115,7 +115,6 @@ class Shell(BuildMTTTool):
         return True
 
     def execute(self, log, keyvals, testDef):
-
         self.testDef = testDef
 
         testDef.logger.verbose_print("Shell Execute")

--- a/pylib/Tools/CNC/IPMITool.py
+++ b/pylib/Tools/CNC/IPMITool.py
@@ -185,7 +185,7 @@ class IPMITool(CNCMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Executor/combinatorial.py
+++ b/pylib/Tools/Executor/combinatorial.py
@@ -59,7 +59,7 @@ class CombinatorialEx(ExecutorMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
 
@@ -174,11 +174,11 @@ class CombinatorialEx(ExecutorMTTTool):
         self.createIniLog(testDef)
         try:
             if not self.runLog:
-                print("Error, empty run log, combinatorial executor failed")
+                testDef.logger.print("Error, empty run log, combinatorial executor failed")
                 sys.exit(1)
             for nextFile in self.runLog:
                 if not os.path.isfile(self.runLog[nextFile]):
-                    print("Test .ini file not found!: " + nextFile)
+                    testDef.logger.print("Test .ini file not found!: " + nextFile)
                     sys.exit(1)
                 testDef.configNewTest(self.runLog[nextFile])
                 sequential_status = testDef.executeTest()

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -65,7 +65,7 @@ class SequentialEx(ExecutorMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def durationTimeoutHandler(self):
@@ -303,9 +303,9 @@ class SequentialEx(ExecutorMTTTool):
                     testDef.logger.stage_end_print(disp_title, stageLog)
 
                     if testDef.options['stop_on_fail'] is not False and stageLog['status'] != 0:
-                        print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))
+                        testDef.logger.print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))
                         try:
-                            print("Section " + stageLog['section'] + ": Stderr " + str(stageLog['stderr']))
+                            testDef.logger.print("Section " + stageLog['section'] + ": Stderr " + str(stageLog['stderr']))
                         except KeyError:
                             pass
                         sys.exit(1)
@@ -326,10 +326,10 @@ class SequentialEx(ExecutorMTTTool):
                             continue
                         p.plugin_object.deactivate()
                     testDef.logger.logResults(disp_title, stageLog)
-                    testDef.logger.verbose_print("=======================================")
-                    testDef.logger.verbose_print("KeyboardInterrupt exception was raised: %s %s" \
+                    print("=======================================")
+                    print("KeyboardInterrupt exception was raised: %s %s" \
                                 % (type(e), str(e)))
-                    testDef.logger.verbose_print("=======================================")
+                    print("=======================================")
                     stageLog['status'] = 0
                     stageLog['stderr'] = ["Exception was raised: %s %s" % (type(e), str(e))]
                     self.status = 1
@@ -344,14 +344,14 @@ class SequentialEx(ExecutorMTTTool):
                         if not p._getIsActivated():
                             continue
                         p.plugin_object.deactivate()
-                    testDef.logger.verbose_print("=======================================")
-                    testDef.logger.verbose_print("Exception was raised: %s %s" \
+                    print("=======================================")
+                    print("Exception was raised: %s %s" \
                                 % (type(e), str(e)))
-                    testDef.logger.verbose_print("=======================================")
+                    print("=======================================")
                     type_, value_, traceback_ = sys.exc_info()
                     ex = traceback.format_exception(type_, value_, traceback_)
-                    testDef.logger.verbose_print("\n".join(ex))
-                    testDef.logger.verbose_print("=======================================")
+                    print("\n".join(ex))
+                    print("=======================================")
                     stageLog['status'] = 1
                     stageLog['stderr'] = ["Exception was raised: %s %s" % (type(e), str(e))]
                     testDef.logger.logResults(disp_title, stageLog)

--- a/pylib/Tools/Fetch/AlreadyInstalled.py
+++ b/pylib/Tools/Fetch/AlreadyInstalled.py
@@ -51,7 +51,7 @@ class AlreadyInstalled(FetchMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Fetch/FetchRPM.py
+++ b/pylib/Tools/Fetch/FetchRPM.py
@@ -63,7 +63,7 @@ class FetchRPM(FetchMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Fetch/FetchTarball.py
+++ b/pylib/Tools/Fetch/FetchTarball.py
@@ -60,7 +60,7 @@ class FetchTarball(FetchMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Fetch/Git.py
+++ b/pylib/Tools/Fetch/Git.py
@@ -70,7 +70,7 @@ class Git(FetchMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Fetch/OMPI_Snapshot.py
+++ b/pylib/Tools/Fetch/OMPI_Snapshot.py
@@ -61,7 +61,7 @@ class OMPI_Snapshot(FetchMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):
@@ -226,7 +226,7 @@ class OMPI_Snapshot(FetchMTTTool):
             if cmds['version_file'] is not None:
                 try:
                     f = open(cmds['version_file'], 'w')
-                    print(snapshot_req.text.strip(), file=f)
+                    testDef.logger.print(snapshot_req.text.strip(), file=f)
                 except:
                     log['status'] = 1
                     log['stderr'] = "FAILED to update version file"

--- a/pylib/Tools/Fetch/Pip.py
+++ b/pylib/Tools/Fetch/Pip.py
@@ -63,7 +63,7 @@ class Pip(FetchMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Harasser/Harasser.py
+++ b/pylib/Tools/Harasser/Harasser.py
@@ -74,7 +74,7 @@ class Harasser(HarasserMTTTool):
         """
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def get_running_harassers(self):

--- a/pylib/Tools/Harasser/HarasserMTTTool.py
+++ b/pylib/Tools/Harasser/HarasserMTTTool.py
@@ -22,5 +22,5 @@ class HarasserMTTTool(IPlugin):
         IPlugin.__init__(self)
 
     def print_name(self):
-        print("Harasser")
+        testDef.logger.print("Harasser")
 

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -91,7 +91,7 @@ class ALPS(LauncherMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Launcher/LauncherMTTTool.py
+++ b/pylib/Tools/Launcher/LauncherMTTTool.py
@@ -43,7 +43,7 @@ class LauncherMTTTool(IPlugin):
         IPlugin.__init__(self)
 
     def print_name(self):
-        print("Launcher")
+        testDef.logger.print("Launcher")
 
     def updateDefaults(self, log, options, keyvals, testDef):
         # check the log for the title so we can

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -96,7 +96,7 @@ class OpenMPI(LauncherMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -99,7 +99,7 @@ class PRRTE(LauncherMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -96,7 +96,7 @@ class SLURM(LauncherMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Tools/Version/MTTVersionPlugin.py
+++ b/pylib/Tools/Version/MTTVersionPlugin.py
@@ -55,7 +55,7 @@ class MTTVersionPlugin(VersionMTTTool):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def getVersion(self):

--- a/pylib/Utilities/Compilers.py
+++ b/pylib/Utilities/Compilers.py
@@ -29,7 +29,7 @@ class Compilers(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, testDef):
@@ -176,12 +176,12 @@ class Compilers(BaseMTTUtility):
         # write out a little test program
         fh = open("spastic.c", 'w')
         for ln in c_code:
-            print(ln, file=fh)
+            testDef.logger.print(ln, file=fh)
         fh.close()
 
         # Attempt to compile it
         mycmdargs = [compiler, "-c", "spastic.c"]
-        results = testDef.execmd.execute(None, mycmdargs, testDef)
+        results = testDef.execmd.execute(None, mycmdargs, testDef, quiet=True)
 
         # cleanup the test
         os.remove("spastic.c")
@@ -215,6 +215,6 @@ class Compilers(BaseMTTUtility):
     def check_version(self, compiler, version, testDef):
         # try the universal version option
         mycmdargs = [compiler, version]
-        results = testDef.execmd.execute(None, mycmdargs, testDef)
+        results = testDef.execmd.execute(None, mycmdargs, testDef, quiet=True)
         return results['status'], results['stdout']
 

--- a/pylib/Utilities/Copy.py
+++ b/pylib/Utilities/Copy.py
@@ -42,7 +42,7 @@ class Copy(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Utilities/Copytree.py
+++ b/pylib/Utilities/Copytree.py
@@ -43,7 +43,7 @@ class Copytree(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Utilities/Environ.py
+++ b/pylib/Utilities/Environ.py
@@ -29,7 +29,7 @@ class Environ(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, keyvals, testDef):

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -103,7 +103,7 @@ class ExecuteCmd(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def _bool_option(self, options, name):
@@ -172,7 +172,7 @@ class ExecuteCmd(BaseMTTUtility):
         return slurm_jobids
 
 
-    def execute(self, options, cmdargs, testDef):
+    def execute(self, options, cmdargs, testDef, quiet=False):
         # if this is a dryrun, just declare success
         if 'dryrun' in testDef.options and testDef.options['dryrun']:
             return (0, [], [], 0)
@@ -234,6 +234,8 @@ class ExecuteCmd(BaseMTTUtility):
         # if it times out, assuming timeout was set
         results = {}
         p = None
+        starttime = None
+        endtime = None
         if time_exec:
             starttime = datetime.datetime.now()
 
@@ -322,6 +324,16 @@ class ExecuteCmd(BaseMTTUtility):
             results['stdout'] = []
             results['stderr'] = [str(e)]
             results['slurm_job_ids'] = []
-            return results
+
+        if not quiet:
+            testDef.logger.log_execmd_elk(cmdargs,
+                                          results['status'] if 'status' in results else None,
+                                          results['stdout'] if 'stdout' in results else None,
+                                          results['stderr'] if 'stderr' in results else None,
+                                          results['timedout'] if 'timedout' in results else None,
+                                          starttime,
+                                          endtime,
+                                          results['elapsed_secs'] if 'elapsed_secs' in results else None,
+                                          results['slurm_job_ids'] if 'slurm_job_ids' in results else None)
 
         return results

--- a/pylib/Utilities/MPIVersion.py
+++ b/pylib/Utilities/MPIVersion.py
@@ -30,7 +30,7 @@ class MPIVersion(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def execute(self, log, testDef):

--- a/pylib/Utilities/ModuleCmd.py
+++ b/pylib/Utilities/ModuleCmd.py
@@ -36,7 +36,7 @@ class ModuleCmd(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     def setCommand(self, options):

--- a/pylib/Utilities/Watchdog.py
+++ b/pylib/Utilities/Watchdog.py
@@ -45,7 +45,7 @@ class Watchdog(BaseMTTUtility):
     def print_options(self, testDef, prefix):
         lines = testDef.printOptions(self.options)
         for line in lines:
-            print(prefix + line)
+            testDef.logger.print(prefix + line)
         return
 
     # Start the watchdog timer


### PR DESCRIPTION
just add --elk flag, and output will change to a more elk-friendly
format

* functionality to redirect all prints to testDef.logger.print
* event logging for
    * each stage
    * each execmd command
    * all options
    * all envvars