### PR TITLE
Fix capturing slurm job id for ompi_hello_world.ini

### DIFF
--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -213,7 +213,7 @@ class ExecuteCmd(BaseMTTUtility):
                 unique_identifier = arg[len('--job-name='):] + unique_identifier
                 arg = '--job-name=' + unique_identifier
                 mycmdargs.append(arg)
-            elif cmdargs[0] == 'srun' and arg == '-J':
+            elif cmdargs[0] == 'srun' and (arg == '-J' or arg == '--job-name'):
                 skip_i.add(i + 1)
                 unique_identifier = cmdargs[i + 1] + unique_identifier
                 mycmdargs.append(arg)


### PR DESCRIPTION
slurm job id failed to capture when srun used "--job-name" without "=". Fixed code to append unique id to job name in this case.

Then job id is captured by checking the unique job name at the end of the job run