### PR TITLE
This fixes a bug where ExecuteCmd shows no stderr from command

### DIFF
--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -260,7 +260,7 @@ class ExecuteCmd(BaseMTTUtility):
             with processTimeout(t, p.pid):
                 # loop until the pipes close
                 while True:
-                    ret = select.select([p.stdout.fileno()], [], [])
+                    ret = select.select([p.stdout.fileno(), p.stderr.fileno()], [], [])
 
                     stdout_done = True
                     stderr_done = True


### PR DESCRIPTION
This bug was introduced in a15b2ce77