### PR TITLE
Limit modifying slurm jobname to only if we're running "srun"

### DIFF
--- a/pylib/Tools/Build/Shell.py
+++ b/pylib/Tools/Build/Shell.py
@@ -93,7 +93,7 @@ class Shell(BuildMTTTool):
             if 0 != results['status']:
                 self.allocated = False
                 log['status'] = results['status']
-                if log['stderr']:
+                if 'stderr' in log:
                     log['stderr'].extend(results['stderr'])
                 else:
                     log['stderr'] = results['stderr']
@@ -106,7 +106,7 @@ class Shell(BuildMTTTool):
             results = testDef.execmd.execute(cmds, deallocate_cmdargs, testDef)
             if 0 != results['status']:
                 log['status'] = results['status']
-                if log['stderr']:
+                if 'stderr' in log:
                     log['stderr'].extend(results['stderr'])
                 else:
                     log['stderr'] = results['stderr']

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -169,7 +169,7 @@ class ExecuteCmd(BaseMTTUtility):
         except:
             pass
 
-        return slurm_jobids
+        return list(set(slurm_jobids))
 
 
     def execute(self, options, cmdargs, testDef, quiet=False):
@@ -196,8 +196,11 @@ class ExecuteCmd(BaseMTTUtility):
         # unique identifier for capturing slurm jobids.
         # This identifier is used in check_for_slurm_jobids() function
         # along with squeue to capture any slurm job ids that contain the identifier
-        unique_identifier = str(random.randint(0,999999999999))
-        os.environ['SLURM_JOB_NAME'] = unique_identifier
+        if cmdargs[0] == 'srun':
+            unique_identifier = str(random.randint(0,999999999999))
+            os.environ['SLURM_JOB_NAME'] = unique_identifier
+        else:
+            unique_identifier = None
 
         # setup the command arguments
         mycmdargs = []
@@ -209,7 +212,7 @@ class ExecuteCmd(BaseMTTUtility):
                 continue
             arg = arg.replace('\"','')
             # Look for any job names in cmdargs, and attach unique identifier
-            if arg.startswith('--job-name='):
+            if cmdargs[0] == 'srun' and arg.startswith('--job-name='):
                 unique_identifier = arg[len('--job-name='):] + unique_identifier
                 arg = '--job-name=' + unique_identifier
                 mycmdargs.append(arg)


### PR DESCRIPTION
srun doesn't show any slurm jobid in its stdout, so we need to modify
SLURM jobid only for srun

sbatch and salloc both output the slurm jobid into the stdout so we can
still capture it there.

This fixes a bug where MTT is overriding the slurm jobname when a user of MTT expects it to not change when using "allocate_cmd" and "deallocate_cmd"

This also fixes a bug in shell.py:
> `if 'stderr' in log:`
> is correct instead of
> `if log['stderr']:`