### PR TITLE
Improved LOG-interpolation syntax and made plugin to debug using that syntax

### DIFF
--- a/docs/pages/user_guide.md
+++ b/docs/pages/user_guide.md
@@ -382,3 +382,61 @@ password = database password
 platform = Your_Platform  
 url = https://mtt.open-mpi.org/submit/cpy/api/  
 
+## Capabilities of MTT
+
+### Accessing environment variables from within an INI file
+
+One useful feature of MTT is the ability of accessing outside environment variables from within an INI file. This enables MTT tests to respond to dynamic input fron the environment.
+
+To access environment variables, use this syntax:
+
+```
+${ENV:ENVIRONMENT_VARIABLE}
+```
+
+MTT will directly substitute the value into the location of the INI file you specified.
+
+If an environment variable does not exist, MTT will warn the user and MTT will exit with an error.
+
+### Accessing the MTT log from within an INI file
+
+Another useful feature of MTT is the ability of accessing results and data from previous stages in the execution of later stages.
+
+To access the MTT log, you must use this syntax:
+
+```
+${LOG:Profile_Installed.status}
+```
+
+The above example is accessing the status of the stage `[Profile:Installed]`. Colons (":") are substituted for underscores ("_"), and dots (".") are used as delimiters for accessing different parts of the data.
+
+You can use the LogInterpolationDebug plugin to view all the contents of the MTT log in the same syntax you would use to access the same data.
+
+This is how to include the LogInterpolationDebug plugin within your INI file:
+
+```
+[Reporter:LogInterpolationDebug]
+plugin = LogInterpolationDebug
+```
+
+After including this plugin in your INI file, the output of your test will include something similar to this to help you determine the correct syntax to use to access the MTT log.
+
+```
+=========================================================================
+START EXECUTING [Reporter:TextFile] start_time=2020-01-06 19:17:00.505503
+=========================================================================
+OPTIONS FOR SECTION: Reporter:TextFile
+  plugin = TextFile
+Executing plugin TextFile
+LOG Interpolation Debugging Tool
+${LOG:MTTDefaults} = { ....................... }
+${LOG:MTTDefaults.keys} = [ ....... ]
+${LOG:MTTDefaults.keys.length} = 7
+${LOG:MTTDefaults.keys.size} = 7
+${LOG:MTTDefaults.keys.0} = section
+${LOG:MTTDefaults.keys.1} = parameters
+${LOG:MTTDefaults.keys.2} = status
+${LOG:MTTDefaults.keys.3} = options
+```
+
+In the above output, notice what looks like `{ ... }` and `[ ... ]`. These are simply where the LogInterpolationDebug plugin is hiding JSON strings that contain data that you can also access directly, and the form in which you access the data directly is also displayed in the debug output.

--- a/pylib/Stages/Reporter/LogInterpolationDebug.py
+++ b/pylib/Stages/Reporter/LogInterpolationDebug.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
+#
+# Copyright (c) 2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+
+import os
+import sys
+from ReporterMTTStage import *
+
+## @addtogroup Stages
+# @{
+# @addtogroup Reporter
+# @section LogInterpolationDebug
+# Debug tool for ${LOG:....} interpolation syntax
+# @}
+class LogInterpolationDebug(ReporterMTTStage):
+
+    def __init__(self):
+        # initialise parent class
+        ReporterMTTStage.__init__(self)
+        self.options = {}
+
+    def activate(self):
+        # get the automatic procedure from IPlugin
+        IPlugin.activate(self)
+        return
+
+
+    def deactivate(self):
+        IPlugin.deactivate(self)
+        return
+
+    def print_name(self):
+        return "LogInterpolationDebug"
+
+    def print_options(self, testDef, prefix):
+        lines = testDef.printOptions(self.options)
+        for line in lines:
+            print(prefix + line)
+        return
+
+    def execute(self, log, keyvals, testDef):
+        self.fh = sys.stdout
+        testDef.logger.verbose_print("LOG Interpolation Debugging Tool")
+
+        config = testDef.config
+
+        for k,v in config._sections['LOG'].items():
+            if v.startswith('{') and v.endswith('}') and not k.split('.')[-1].isnumeric():
+                if len(v) <= 2:
+                    print('${LOG:%s} = {}' % k)
+                else:
+                    print('${LOG:%s} = {' % k, '.' * max(3, v.count(',') + 1), '}')
+            elif v.startswith('[') and v.endswith(']') and not k.split('.')[-1].isnumeric():
+                if len(v) <= 2:
+                    print('${LOG:%s} = []' % k)
+                else:
+                    print('${LOG:%s} = [' % k, '.' * max(3, v.count(',') + 1), ']')
+            else:
+                print('${LOG:%s} = %s' % (k, v))
+
+        log['status'] = 0
+        return

--- a/pylib/Stages/Reporter/LogInterpolationDebug.yapsy-plugin
+++ b/pylib/Stages/Reporter/LogInterpolationDebug.yapsy-plugin
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+[Core]
+Name = LOG Interpolation Debug plugin
+Module = LogInterpolationDebug
+
+[Documentation]
+Author = Richard Barella
+Version = 0.1
+Website = N/A
+Description = Debug tool for ${LOG:....} interpolation syntax

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -23,6 +23,7 @@ import datetime
 from distutils.spawn import find_executable
 from threading import Semaphore
 from pathlib import Path
+import json
 
 is_py2 = sys.version[0] == '2'
 
@@ -528,12 +529,17 @@ class TestDef(object):
         if isinstance(sublog, str):
             self.config.set("LOG", basestr, sublog.replace("$","$$"))
         elif isinstance(sublog, dict):
+            self.fill_log_interpolation(basestr, str(json.dumps(sublog, default=str)))
+            self.fill_log_interpolation("%s.keys" % basestr, list(sublog.keys()))
             for k,v in list(sublog.items()):
                 self.fill_log_interpolation("%s.%s" % (basestr, k), v)
         elif isinstance(sublog, list):
-            if sum([((isinstance(t, list) or isinstance(t, tuple)) and len(t) == 2) for t in sublog]) == len(sublog):
+            if sum([((isinstance(t, list) or isinstance(t, tuple)) and len(t) == 2) for t in sublog]) == len(sublog) and len(sublog) > 0:
                 self.fill_log_interpolation(basestr, {k:v for k,v in sublog})
             else:
+                self.fill_log_interpolation(basestr, str(json.dumps(sublog, default=str)))
+                self.fill_log_interpolation("%s.length" % basestr, str(len(sublog)))
+                self.fill_log_interpolation("%s.size" % basestr, str(len(sublog)))
                 for i,v in enumerate(sublog):
                     self.fill_log_interpolation("%s.%d" % (basestr, i), v)
         else:


### PR DESCRIPTION
This syntax is something like ${LOG:TestRun_mystage.status} which enables you to access
the internal MTT log from an INI file. This is a powerful feature which I have been able
to use to even make an INI file that tests itself.

Includes enhances to documentation regarding `${ENV: ...}` and `{LOG: ...}` interpolation syntax