### PR TITLE
Moved ElkLogger functionality into its own module

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -277,6 +277,9 @@ if args.section and args.skipsections:
 # to stdout
 testDef.openLogger()
 
+# open the elk logger if given, otherwise don't log to *.elog files
+testDef.openElkLogger()
+
 # Read the input test definition file(s)
 testDef.configTest()
 

--- a/pylib/System/TestDef.py
+++ b/pylib/System/TestDef.py
@@ -61,6 +61,8 @@ class TestDef(object):
         # set aside a spot for a logger object, and
         # note that it hasn't yet been defined
         self.logger = None
+        # set aside a spot for the elkLogger object
+        self.elkLogger = None
         self.modcmd = None
         # set aside per stage environment module requests
         self.module_unload = {}
@@ -524,6 +526,12 @@ class TestDef(object):
         self.logger = self.utilities.getPluginByName("Logger", "Base").plugin_object
         self.logger.open(self)
         return
+
+    def openElkLogger(self):
+        if not self.utilities.activatePluginByName("ElkLogger", "Base"):
+            self.elkLogger = None
+        else:
+            self.elkLogger = self.utilities.getPluginByName("ElkLogger", "Base").plugin_object
 
     def fill_log_interpolation(self, basestr, sublog):
         if isinstance(sublog, str):

--- a/pylib/Utilities/ElkLogger.py
+++ b/pylib/Utilities/ElkLogger.py
@@ -15,6 +15,7 @@ import datetime
 from BaseMTTUtility import *
 import json
 import os
+from pathlib import Path
 import pwd
 import grp
 
@@ -80,14 +81,16 @@ class ElkLogger(BaseMTTUtility):
                 result['profile'] = { k:' '.join(v) for k,v in list(result['profile'].items()) }
 
         if testDef.options['elk_debug']:
-            testDef.logger.verbose_print('Logging to elk_head={}/{}.elog: {}'.format(testDef.options['elk_head'], testDef.options['elk_id'], result))
+            testDef.logger.verbose_print('Logging to elk_head={}/{}-{}.elog: {}'.format(testDef.options['elk_head'],
+                                                                                        testDef.options['elk_testcase'],
+                                                                                        testDef.options['elk_id'], result))
 
         if self.elk_log is None:
             allpath = '/'
             for d in os.path.normpath(testDef.options['elk_head']).split(os.path.sep):
                 allpath = os.path.join(allpath, d)
                 if not os.path.exists(allpath):
-                    os.mkdir(allpath)
+                    Path(allpath).mkdir(parents=True, exist_ok=True)
                     uid = None
                     gid = None
                     if testDef.options['elk_chown'] is not None and ':' in testDef.options['elk_chown']:

--- a/pylib/Utilities/ElkLogger.py
+++ b/pylib/Utilities/ElkLogger.py
@@ -2,7 +2,7 @@
 from builtins import str
 #!/usr/bin/env python
 #
-# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2020 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,6 +24,15 @@ import grp
 # @section ElkLogger
 # Log results to *.elog files with JSON entries to be later consumed by Elastic Stack (ELK)
 # Uses pymtt.py options: elk_head, elk_id, elk_testcycle, elk_testcase, elk_debug, elk_chown, elk_maxsize, elk_nostdout, elk_nostderr 
+#
+# --elk_testcase specifies which testcase to log results as when using elk-friendly ouput. Also set through environment variable MTT_ELK_TESTCASE
+# --elk_testcycle specifies which testcycle to log results as when using elk-friendly output. Also set through environment variable MTT_ELK_TESTCYCLE
+# --elk_id specifies which execution id to log results as when using elk-friendly output. Also set through environment variable MTT_ELK_ID
+# --elk_head specifies which location to log <caseid>_<elk_id>.elog files for elk_friendly output. Also set through environment variable MTT_ELK_HEAD
+# --elk_chown specifies a max number of lines to log for stdout and stderr in elk-friendly output. Also set through environment variable MTT_ELK_CHOWN
+# --elk_nostdout specifies whether to include stdout in elk-friendly output. Also set through environment variable MTT_ELK_NOSTDOUT
+# --elk_nostderr specifies whether to include stderr in elk-friendly output. Also set through environment variable MTT_ELK_NOSTDERR
+# --elk_debug specifies whether to output everything logged to *.elog files to the screen as extra verbose output. Also set through environment variable MTT_ELK_DEBUG
 # @}
 class ElkLogger(BaseMTTUtility):
     def __init__(self):

--- a/pylib/Utilities/ElkLogger.py
+++ b/pylib/Utilities/ElkLogger.py
@@ -1,0 +1,129 @@
+
+from builtins import str
+#!/usr/bin/env python
+#
+# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+import sys
+import datetime
+from BaseMTTUtility import *
+import json
+import os
+import pwd
+import grp
+
+## @addtogroup Utilities
+# @{
+# @section ElkLogger
+# Log results to *.elog files with JSON entries to be later consumed by Elastic Stack (ELK)
+# Uses pymtt.py options: elk_head, elk_id, elk_testcycle, elk_testcase, elk_debug, elk_chown, elk_maxsize, elk_nostdout, elk_nostderr 
+# @}
+class ElkLogger(BaseMTTUtility):
+    def __init__(self):
+        BaseMTTUtility.__init__(self)
+        self.options = {}
+        self.elk_log = None
+        self.execmds_stash = []
+
+    def print_name(self):
+        return "ElkLogger"
+
+    def print_options(self, testDef, prefix):
+        lines = testDef.printOptions(self.options)
+        for line in lines:
+            print(prefix + line)
+            sys.stdout.flush()
+        return
+
+    def log_to_elk(self, result, logtype, testDef):
+        result = result.copy()
+        if testDef.options['elk_head'] is None or testDef.options['elk_id'] is None:
+            testDef.logger.verbose_print('Error: entered log_to_elk() function without elk_id and elk_head specified')
+            return
+
+        result = {k:(str(v) if isinstance(v, datetime.datetime)
+                            or isinstance(v, datetime.date) else v)
+                  for k,v in list(result.items())}
+        result['execid'] = testDef.options['elk_id']
+        result['cycleid'] = testDef.options['elk_testcycle']
+        result['caseid'] = testDef.options['elk_testcase']
+        result['logtype'] = logtype
+
+        # drop the stderr and stdout, will use the copies that are part of the commands issues
+        if 'stderr' in result:
+            del result['stderr']
+        if 'stdout' in result:
+            del result['stdout']
+
+        # convert ini_files, lists of lists into a comma separated string
+        if 'options' in result and 'ini_files' in result['options']:
+            result['options']['ini_files'] = ','.join(t[0] for t in result['options']['ini_files'])
+
+        if logtype == 'mtt-sec':
+            # convert comamands, list of dicts into a dictionary
+            if self.execmds_stash:
+                result['commands'] = {"command{}".format(i):c for i,c in enumerate(self.execmds_stash)}
+                self.execmds_stash = []
+
+            # convert parameters, list of lists into a dictionary
+            if 'parameters' in result:
+                result['parameters'] = { p[0]:p[1] for p in result['parameters'] }
+
+            # convert profile, list of lists into a dictionary
+            if 'profile' in result:
+                result['profile'] = { k:' '.join(v) for k,v in list(result['profile'].items()) }
+
+        if testDef.options['elk_debug']:
+            testDef.logger.verbose_print('Logging to elk_head={}/{}.elog: {}'.format(testDef.options['elk_head'], testDef.options['elk_id'], result))
+
+        if self.elk_log is None:
+            allpath = '/'
+            for d in os.path.normpath(testDef.options['elk_head']).split(os.path.sep):
+                allpath = os.path.join(allpath, d)
+                if not os.path.exists(allpath):
+                    os.mkdir(allpath)
+                    uid = None
+                    gid = None
+                    if testDef.options['elk_chown'] is not None and ':' in testDef.options['elk_chown']:
+                        user = testDef.options['elk_chown'].split(':')[0]
+                        group = testDef.options['elk_chown'].split(':')[1]
+                        uid = pwd.getpwnam(user).pw_uid
+                        gid = grp.getgrnam(group).gr_gid
+                        os.chown(allpath, uid, gid)
+            self.elk_log = open(os.path.join(testDef.options['elk_head'], '{}-{}.elog'.format(testDef.options['elk_testcase'], testDef.options['elk_id'])), 'a+')
+        self.elk_log.write(json.dumps(result) + '\n')
+        return
+
+    def log_execmd_elk(self, cmdargs, status, stdout, stderr, timedout, starttime, endtime, elapsed_secs, slurm_job_ids, testDef):
+        if testDef.options['elk_id'] is not None:
+            if testDef.options['elk_maxsize'] is not None:
+                try:
+                    maxsize = int(testDef.options['elk_maxsize'])
+                except:
+                    maxsize = None
+                if maxsize is not None and len(stdout) > maxsize:
+                    if maxsize > 0:
+                        stdout = ['<truncated>'] + stdout[-maxsize:]
+                    else:
+                        stdout = ['<truncated>']
+                if maxsize is not None and len(stderr) > maxsize:
+                    if maxsize > 0:
+                        stderr = ['<truncated>'] + stderr[-maxsize:]
+                    else:
+                        stderr = ['<truncated>']
+            self.execmds_stash.append({'cmdargs': ' '.join(cmdargs),
+                                       'status': status,
+                                       'stdout': stdout if testDef.options['elk_nostdout'] is not None else ['<ignored>'],
+                                       'stderr': stderr if testDef.options['elk_nostderr'] is not None else ['<ignored>'],
+                                       'timedout': timedout,
+                                       'starttime': str(starttime),
+                                       'endtime': str(endtime),
+                                       'elapsed': elapsed_secs,
+                                       'slurm_job_ids': ','.join([str(j) for j in slurm_job_ids])
+                                      })

--- a/pylib/Utilities/ElkLogger.yapsy-plugin
+++ b/pylib/Utilities/ElkLogger.yapsy-plugin
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+[Core]
+Name = ElkLogger
+Module = ElkLogger
+
+[Documentation]
+Author = Richard Barella
+Version = 0.1
+Website = N/A
+Description = Log results to *.elog files with JSON entries to be later consumed by Elastic Stack (ELK). Uses pymtt.py options: elk_head, elk_id, elk_testcycle, elk_testcase, elk_debug, elk_chown, elk_maxsize, elk_nostdout, elk_nostderr 

--- a/pylib/Utilities/ElkLogger.yapsy-plugin
+++ b/pylib/Utilities/ElkLogger.yapsy-plugin
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2020 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -227,15 +227,15 @@ class ExecuteCmd(BaseMTTUtility):
 
         if not mycmdargs:
             testDef.logger.verbose_print("ExecuteCmd error: no cmdargs")
-            if not quiet:
-                testDef.logger.log_execmd_elk(cmdargs,
-                                              1, None,
-                                              'ExecuteCmd error: no cmdargs',
-                                              None,
-                                              datetime.datetime.now(),
-                                              datetime.datetime.now(),
-                                              0, None,
-                                              testDef)
+            if not quiet and testDef.elkLogger is not None and testDef.options['elk_id'] is not None:
+                testDef.elkLogger.log_execmd_elk(cmdargs,
+                                                 1, None,
+                                                 'ExecuteCmd error: no cmdargs',
+                                                 None,
+                                                 datetime.datetime.now(),
+                                                 datetime.datetime.now(),
+                                                 0, None,
+                                                 testDef)
             return (1, [], ["MTT ExecuteCmd error: no cmdargs"], 0)
 
         # define storage to catch the output
@@ -313,17 +313,17 @@ class ExecuteCmd(BaseMTTUtility):
                     elapsed_datetime = endtime - starttime
                     results['elapsed_secs'] = elapsed_datetime.total_seconds()
 
-                if not quiet:
-                    testDef.logger.log_execmd_elk(cmdargs,
-                                                  results['status'] if 'status' in results else None,
-                                                  results['stdout'] if 'stdout' in results else None,
-                                                  results['stderr'] if 'stderr' in results else None,
-                                                  results['timedout'] if 'timedout' in results else None,
-                                                  starttime,
-                                                  endtime,
-                                                  (endtime - starttime).total_seconds,
-                                                  results['slurm_job_ids'] if 'slurm_job_ids' in results else None,
-                                                  testDef)
+                if not quiet and testDef.elkLogger is not None and testDef.options['elk_id'] is not None:
+                    testDef.elkLogger.log_execmd_elk(cmdargs,
+                                                     results['status'] if 'status' in results else None,
+                                                     results['stdout'] if 'stdout' in results else None,
+                                                     results['stderr'] if 'stderr' in results else None,
+                                                     results['timedout'] if 'timedout' in results else None,
+                                                     starttime,
+                                                     endtime,
+                                                     (endtime - starttime).total_seconds,
+                                                     results['slurm_job_ids'] if 'slurm_job_ids' in results else None,
+                                                     testDef)
                 return results
 
             if time_exec:
@@ -350,16 +350,16 @@ class ExecuteCmd(BaseMTTUtility):
             results['stderr'] = [str(e)]
             results['slurm_job_ids'] = []
 
-        if not quiet:
-            testDef.logger.log_execmd_elk(cmdargs,
-                                          results['status'] if 'status' in results else None,
-                                          results['stdout'] if 'stdout' in results else None,
-                                          results['stderr'] if 'stderr' in results else None,
-                                          results['timedout'] if 'timedout' in results else None,
-                                          starttime,
-                                          endtime,
-                                          (endtime - starttime).total_seconds(),
-                                          results['slurm_job_ids'] if 'slurm_job_ids' in results else None,
-                                          testDef)
+        if not quiet and testDef.elkLogger is not None and testDef.options['elk_id'] is not None:
+            testDef.elkLogger.log_execmd_elk(cmdargs,
+                                             results['status'] if 'status' in results else None,
+                                             results['stdout'] if 'stdout' in results else None,
+                                             results['stderr'] if 'stderr' in results else None,
+                                             results['timedout'] if 'timedout' in results else None,
+                                             starttime,
+                                             endtime,
+                                             (endtime - starttime).total_seconds(),
+                                             results['slurm_job_ids'] if 'slurm_job_ids' in results else None,
+                                             testDef)
 
         return results

--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -11,12 +11,9 @@ from builtins import str
 #
 
 import sys
+import os
 import datetime
 from BaseMTTUtility import *
-import json
-import os
-import pwd
-import grp
 
 ## @addtogroup Utilities
 # @{
@@ -34,9 +31,6 @@ class Logger(BaseMTTUtility):
         self.cmdtimestamp = False
         self.timestampeverything = False
         self.stage_start = {}
-        self.elk_log = None
-        self.current_section = None
-        self.execmds_stash = []
 
     def reset(self):
         self.results = []
@@ -109,65 +103,6 @@ class Logger(BaseMTTUtility):
         max_keylen = max([len(key) for key,_ in tuplelist])
         return ["%s = %s" % (k.rjust(max_keylen), o) for k,o in tuplelist]
 
-    def log_to_elk(self, result, logtype, testDef):
-        result = result.copy()
-        if testDef.options['elk_head'] is None or testDef.options['elk_id'] is None:
-            self.verbose_print('Error: entered log_to_elk() function without elk_id and elk_head specified')
-            return
-
-        result = {k:(str(v) if isinstance(v, datetime.datetime)
-                            or isinstance(v, datetime.date) else v)
-                  for k,v in list(result.items())}
-        result['execid'] = testDef.options['elk_id']
-        result['cycleid'] = testDef.options['elk_testcycle']
-        result['caseid'] = testDef.options['elk_testcase']
-        result['logtype'] = logtype
-
-        # drop the stderr and stdout, will use the copies that are part of the commands issues
-        if 'stderr' in result:
-            del result['stderr']
-        if 'stdout' in result:
-            del result['stdout']
-
-        # convert ini_files, lists of lists into a comma separated string
-        if 'options' in result and 'ini_files' in result['options']:
-            result['options']['ini_files'] = ','.join(t[0] for t in result['options']['ini_files'])
-
-        if logtype == 'mtt-sec':
-            # convert comamands, list of dicts into a dictionary
-            if self.execmds_stash:
-                result['commands'] = {"command{}".format(i):c for i,c in enumerate(self.execmds_stash)}
-                self.execmds_stash = []
-
-            # convert parameters, list of lists into a dictionary
-            if 'parameters' in result:
-                result['parameters'] = { p[0]:p[1] for p in result['parameters'] }
-
-            # convert profile, list of lists into a dictionary
-            if 'profile' in result:
-                result['profile'] = { k:' '.join(v) for k,v in list(result['profile'].items()) }
-
-        if testDef.options['elk_debug']:
-            self.verbose_print('Logging to elk_head={}/{}.elog: {}'.format(testDef.options['elk_head'], testDef.options['elk_id'], result))
-
-        if self.elk_log is None:
-            allpath = '/'
-            for d in os.path.normpath(testDef.options['elk_head']).split(os.path.sep):
-                allpath = os.path.join(allpath, d)
-                if not os.path.exists(allpath):
-                    os.mkdir(allpath)
-                    uid = None
-                    gid = None
-                    if testDef.options['elk_chown'] is not None and ':' in testDef.options['elk_chown']:
-                        user = testDef.options['elk_chown'].split(':')[0]
-                        group = testDef.options['elk_chown'].split(':')[1]
-                        uid = pwd.getpwnam(user).pw_uid
-                        gid = grp.getgrnam(group).gr_gid
-                        os.chown(allpath, uid, gid)
-            self.elk_log = open(os.path.join(testDef.options['elk_head'], '{}-{}.elog'.format(testDef.options['elk_testcase'], testDef.options['elk_id'])), 'a+')
-        self.elk_log.write(json.dumps(result) + '\n')
-        return
-
     def print_cmdline_args(self, testDef):
         if not (testDef and testDef.options):
             print("Error: print_cmdline_args was called too soon. Continuing...")
@@ -181,36 +116,9 @@ class Logger(BaseMTTUtility):
         for s in strs_to_print:
             self.verbose_print(s)
         self.verbose_print("")
-        if testDef.options['elk_id'] is not None:
-            self.log_to_elk({'environment': dict(os.environ), 'options': testDef.options}, 'mtt-env', testDef)
-
-    def log_execmd_elk(self, cmdargs, status, stdout, stderr, timedout, starttime, endtime, elapsed_secs, slurm_job_ids, testDef):
-        if testDef.options['elk_id'] is not None:
-            if testDef.options['elk_maxsize'] is not None:
-                try:
-                    maxsize = int(testDef.options['elk_maxsize'])
-                except:
-                    maxsize = None
-                if maxsize is not None and len(stdout) > maxsize:
-                    if maxsize > 0:
-                        stdout = ['<truncated>'] + stdout[-maxsize:]
-                    else:
-                        stdout = ['<truncated>']
-                if maxsize is not None and len(stderr) > maxsize:
-                    if maxsize > 0:
-                        stderr = ['<truncated>'] + stderr[-maxsize:]
-                    else:
-                        stderr = ['<truncated>']
-            self.execmds_stash.append({'cmdargs': ' '.join(cmdargs),
-                                       'status': status,
-                                       'stdout': stdout if testDef.options['elk_nostdout'] is not None else ['<ignored>'],
-                                       'stderr': stderr if testDef.options['elk_nostderr'] is not None else ['<ignored>'],
-                                       'timedout': timedout,
-                                       'starttime': str(starttime),
-                                       'endtime': str(endtime),
-                                       'elapsed': elapsed_secs,
-                                       'slurm_job_ids': ','.join([str(j) for j in slurm_job_ids])
-                                      })
+        # Log to elog file for injesting into ELK
+        if testDef.elkLogger is not None and testDef.options['elk_id'] is not None:
+            testDef.elkLogger.log_to_elk({'environment': dict(os.environ), 'options': testDef.options}, 'mtt-env', testDef)
 
     def stage_start_print(self, stagename):
         self.stage_start[stagename] = datetime.datetime.now()
@@ -220,7 +128,6 @@ class Logger(BaseMTTUtility):
             self.verbose_print("="*len(to_print))
             self.verbose_print(to_print)
             self.verbose_print("="*len(to_print))
-        self.current_section = stagename
 
     def stage_end_print(self, stagename, log):
         stage_end = datetime.datetime.now()
@@ -232,7 +139,6 @@ class Logger(BaseMTTUtility):
         log['elapsed'] = (stage_end-self.stage_start[stagename]).total_seconds()
         log['starttime'] = self.stage_start[stagename]
         log['endtime'] = stage_end
-        self.current_section = None
 
     def verbose_print(self, string, timestamp=None):
         if self.printout:
@@ -258,8 +164,9 @@ class Logger(BaseMTTUtility):
     def logResults(self, title, result, testDef):
         self.verbose_print("LOGGING results for " + title)
         self.results.append(result)
-        if testDef.options['elk_id'] is not None:
-            self.log_to_elk(result, 'mtt-sec', testDef)
+        # Log to elog file for injesting into ELK
+        if testDef.elkLogger is not None and testDef.options['elk_id'] is not None:
+            testDef.elkLogger.log_to_elk(result, 'mtt-sec', testDef)
         return
 
     def outputLog(self):


### PR DESCRIPTION
This is to reduce confusion when maintaining Logger.py

There is also a minor fix to a race condition in creating the elog files which uses `pathlib.Path` to create directories and not error out out if they already exist.