### PR TITLE
Parens () missing in sending total_seconds to elklogger when catching timeout

### DIFF
--- a/pylib/Utilities/ExecuteCmd.py
+++ b/pylib/Utilities/ExecuteCmd.py
@@ -324,7 +324,7 @@ class ExecuteCmd(BaseMTTUtility):
                                                      results['timedout'] if 'timedout' in results else None,
                                                      starttime,
                                                      endtime,
-                                                     (endtime - starttime).total_seconds,
+                                                     (endtime - starttime).total_seconds(),
                                                      results['slurm_job_ids'] if 'slurm_job_ids' in results else None,
                                                      testDef)
                 return results


### PR DESCRIPTION
Signed-off-by: Richard Barella <richard.t.barella@email.com>