### PR TITLE
reverting jenkins version and plugin add

### DIFF
--- a/tests/jenkins/Dockerfile
+++ b/tests/jenkins/Dockerfile
@@ -1,5 +1,4 @@
-#FROM jenkins/jenkins:lts
-FROM jenkins/jenkins:2.190.1
+FROM jenkins/jenkins:lts
 LABEL maintainer.primary="richard.t.barella@intel.com" \
       maintainer.secondary="william.c.weide@intel.com"
 

--- a/tests/jenkins/plugins.txt
+++ b/tests/jenkins/plugins.txt
@@ -88,7 +88,6 @@ maven-plugin:
 mercurial:
 momentjs:
 multiple-scms:
-Office-365-Connector:
 pam-auth:
 parameterized-trigger:
 pipeline-aggregator-view:


### PR DESCRIPTION
moving the jenkins version back to lts and removing the Office 365
Connector plugin as this has other incompatiblies in need to figure out

Signed-off-by: Bill Weide <william.c.weide@intel.com>