### PR TITLE
cherrypy: fix syntax for launching mttserver

### DIFF
--- a/server/php/cherrypy/bin/mtt_server_service.py
+++ b/server/php/cherrypy/bin/mtt_server_service.py
@@ -70,7 +70,7 @@ def _start():
 
     if -2 == pid:
         # PIDFile not found, thus, server is not running.
-        call(['env/bin/python', _script_name])
+        call(['python', _script_name])
         return
     elif -1 == pid:
         print("PIDFile '%s' has been corrupted." % _src_dir + '/' +_pidfile)


### PR DESCRIPTION
the existin syntax broke on after upgrading OpenMPI community
jenkins server to ubuntu2004.  Ended up mixing python3 and python2

Signed-off-by: Howard Pritchard <howardp@lanl.gov>