### PR TITLE
add support for checkpoint/restart of mtt logfiles

### DIFF
--- a/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
+++ b/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,6 +30,7 @@ from MTTDefaultsMTTStage import *
 # @param stderr_save_lines     Number of lines of stderr to save (-1 for unlimited)
 # @param executor              Strategy to use: combinatorial or sequential executor
 # @param time                  Record how long it takes to run each individual test
+# @param restart_file          Optional restart log file 
 # @}
 class DefaultMTTDefaults(MTTDefaultsMTTStage):
 
@@ -45,6 +48,7 @@ class DefaultMTTDefaults(MTTDefaultsMTTStage):
         self.options['stderr_save_lines'] = (-1, "Number of lines of stderr to save (-1 for unlimited)")
         self.options['executor'] = ('sequential', "Strategy to use: combinatorial or sequential executor")
         self.options['time'] = (True, "Record how long it takes to run each individual test")
+        self.options['restart_file'] = (None, "Log restart file")
         return
 
     def activate(self):
@@ -108,9 +112,15 @@ class DefaultMTTDefaults(MTTDefaultsMTTStage):
         # the parseOptions function will record status for us
         testDef.parseOptions(log, self.options, keyvals, cmds)
 
+        if cmds['restart_file'] is not None:
+            testDef.logger.restartLog(str(cmds['restart_file']))
+
         # we need to record the results into our options so
         # subsequent sections can capture them
         keys = list(cmds.keys())
         for key in keys:
             self.options[key] = (cmds[key], self.options[key][1])
+        return
+
+    def savelog(self, testDef):
         return

--- a/pylib/Stages/Profile/DefaultProfile.py
+++ b/pylib/Stages/Profile/DefaultProfile.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -84,4 +86,7 @@ class DefaultProfile(ProfileMTTStage):
         # add our log to the system log
         log['profile'] = myLog
         log['status'] = 0
+        return
+
+    def savelog(self, testDef):
         return

--- a/pylib/Stages/TestBuild/DefaultTestBuild.py
+++ b/pylib/Stages/TestBuild/DefaultTestBuild.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,6 +29,7 @@ from TestBuildMTTStage import *
 # @param make_options              Options to be passed to the make command
 # @param make_envars               Environmental variables to set prior to executing make
 # @param subdir                    Subdirectory of location that is to be built
+# @param checkpoint_file           Optional checkpoint file
 # @}
 class DefaultTestBuild(TestBuildMTTStage):
 
@@ -44,6 +47,8 @@ class DefaultTestBuild(TestBuildMTTStage):
         self.options['make_options'] = (None, "Options to be passed to the make command")
         self.options['make_envars'] = (None, "Environmental variables to set prior to executing make")
         self.options['subdir'] = (None, "Subdirectory of location that is to be built")
+        self.options['checkpoint_file'] = (None, "Checkpoint file")
+        self.checkpoint_file = ''
 
     def activate(self):
         # get the automatic procedure from IPlugin
@@ -72,6 +77,10 @@ class DefaultTestBuild(TestBuildMTTStage):
         # add our section header back into the cmds as it will
         # be needed by autotools
         cmds['section'] = keyvals['section']
+
+        if cmds['checkpoint_file'] is not None:
+            self.checkpoint_file = cmds['checkpoint_file']
+
         # if this test requires middleware, the user
         # should have told us so by specifying the
         # corresponding middlewareBuild stage for it.
@@ -150,4 +159,10 @@ class DefaultTestBuild(TestBuildMTTStage):
         if midpath:
             os.environ['PATH'] = oldbinpath
             os.environ['LD_LIBRARY_PATH'] = oldldlibpath
+
+        return
+
+    def savelog(self,testDef):
+        if self.checkpoint_file is not None:
+            testDef.logger.checkpointLog(self.checkpoint_file)
         return

--- a/pylib/Tools/Build/Autotools.py
+++ b/pylib/Tools/Build/Autotools.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,6 +39,7 @@ from BuildMTTTool import *
 # @param dependencies              List of dependencies specified as the build stage name
 # @param make_envars               Environmental variables to set prior to executing make
 # @param subdir                    Subdirectory that is to be built
+# @param checkpoint_file           Optional checkpoint file
 
 # @}
 class Autotools(BuildMTTTool):
@@ -59,6 +62,8 @@ class Autotools(BuildMTTTool):
         self.options['dependencies'] = (None, "List of dependencies specified as the build stage name - e.g., MiddlwareBuild_package to be added to configure using --with-package=location")
         self.options['make_envars'] = (None, "Environmental variables to set prior to executing make")
         self.options['subdir'] = (None, "Subdirectory that is to be built")
+        self.options['checkpoint_file'] = (None, "Checkpoint file")
+        self.checkpoint_file=''
         self.exclude = set(string.punctuation)
         return
 
@@ -119,6 +124,9 @@ class Autotools(BuildMTTTool):
             log['status'] = 1
             log['stderr'] = "Location of package to build was not specified in parent stage"
             return
+
+        if cmds['checkpoint_file'] is not None:
+            self.checkpoint_file = cmds['checkpoint_file']
 
         # see if we need to adjust the location to build what is in
         # a specific subdirectory of this location
@@ -600,4 +608,9 @@ class Autotools(BuildMTTTool):
         for en in loadedenv:
             del os.environ[en]
 
+        return
+
+    def savelog(self,testDef):
+        if self.checkpoint_file is not None:
+            testDef.logger.checkpointLog(self.checkpoint_file)
         return

--- a/pylib/Tools/Executor/sequential.py
+++ b/pylib/Tools/Executor/sequential.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -290,11 +292,20 @@ class SequentialEx(ExecutorMTTTool):
                     if 'stderr' in stageLog and isinstance(stageLog['stderr'], str):
                         stageLog['stderr'] = stageLog['stderr'].split("\n")
 
+                    # Log results for section
+                    testDef.logger.logResults(disp_title, stageLog, testDef)
+
                     # Print end of section
                     testDef.logger.stage_end_print(disp_title, stageLog)
 
-                    # Log results for section
-                    testDef.logger.logResults(disp_title, stageLog, testDef)
+                    # Optional save log
+                    try:
+                        plugin.savelog(testDef)
+                    except:
+                        continue
+
+#                   # Log results for section
+#                   testDef.logger.logResults(disp_title, stageLog, testDef)
 
                     if testDef.options['stop_on_fail'] is not False and stageLog['status'] != 0:
                         print("Section " + stageLog['section'] + ": Status " + str(stageLog['status']))

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -38,7 +40,8 @@ import shlex
 # @param allocate_cmd              Command to use for allocating nodes from the resource manager
 # @param deallocate_cmd            Command to use for deallocating nodes from the resource manager
 # @param dependencies              List of dependencies specified as the build stage name
-# @}
+# @param checkpoint_file           Optional checkpoint file
+ @}
 class ALPS(LauncherMTTTool):
 
     def __init__(self):
@@ -65,6 +68,8 @@ class ALPS(LauncherMTTTool):
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
         self.options['dependencies'] = (None, "List of dependencies specified as the build stage name - e.g., MiddlwareBuild_package to be added to configure using --with-package=location")
+        self.options['checkpoint_file'] = (None, "Checkpoint file")
+        self.checkpoint_file=''
 
         self.allocated = False
         self.testDef = None
@@ -101,7 +106,11 @@ class ALPS(LauncherMTTTool):
         # parse any provided options - these will override the defaults
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
+
         self.cmds = cmds
+
+        if cmds['checkpoint_file'] is not None:
+            self.checkpoint_file = cmds['checkpoint_file']
 
         # check the log for the title so we can
         # see if this is setting our default behavior
@@ -176,3 +185,9 @@ class ALPS(LauncherMTTTool):
             log['np'] = cmds['np']
 
         return
+
+    def savelog(self,testDef):
+        if self.checkpoint_file is not None:
+            testDef.logger.checkpointLog(self.checkpoint_file)
+        return
+

--- a/pylib/Tools/Launcher/ALPS.py
+++ b/pylib/Tools/Launcher/ALPS.py
@@ -41,7 +41,7 @@ import shlex
 # @param deallocate_cmd            Command to use for deallocating nodes from the resource manager
 # @param dependencies              List of dependencies specified as the build stage name
 # @param checkpoint_file           Optional checkpoint file
- @}
+# @}
 class ALPS(LauncherMTTTool):
 
     def __init__(self):

--- a/pylib/Tools/Launcher/OpenMPI.py
+++ b/pylib/Tools/Launcher/OpenMPI.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,6 +44,7 @@ import shlex
 # @param modules         Modules to load
 # @param modules_swap    Modules to swap
 # @param dependencies              List of dependencies specified as the build stage name
+# @param checkpoint_file           Optional checkoutpoint file
 # @}
 class OpenMPI(LauncherMTTTool):
 
@@ -71,7 +74,9 @@ class OpenMPI(LauncherMTTTool):
         self.options['modules_unload'] = (None, "Modules to unload")
         self.options['modules_swap'] = (None, "Modules to swap")
         self.options['dependencies'] = (None, "List of dependencies specified as the build stage name - e.g., MiddlwareBuild_package to be added to configure using --with-package=location")
+        self.options['checkpoint_file'] = (None, "Log restart file")
 
+        self.checkpoint_file=''
         self.allocated = False
         self.testDef = None
         self.cmds = None
@@ -107,6 +112,9 @@ class OpenMPI(LauncherMTTTool):
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
         self.cmds = cmds
+
+        if cmds['checkpoint_file'] is not None:
+            self.checkpoint_file = cmds['checkpoint_file']
 
         # update our defaults, if requested
         status = self.updateDefaults(log, self.options, keyvals, testDef)
@@ -161,3 +169,13 @@ class OpenMPI(LauncherMTTTool):
         self.resetPaths(log, testDef)
 
         return
+
+    def savelog(self,testDef):
+        if self.checkpoint_file is not None:
+            try: 
+                testDef.logger.checkpointLog(self.checkpoint_file)
+            except General as X: 
+                print("checkpoint failed - CAUGHT " + X.__class__)
+                
+        return
+

--- a/pylib/Tools/Launcher/PRRTE.py
+++ b/pylib/Tools/Launcher/PRRTE.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Los Alamos National Security, LLC. All rights
 #                         reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,6 +46,7 @@ from subprocess import Popen, PIPE
 # @param modules_swap    Modules to swap
 # @param dependencies              List of dependencies specified as the build stage name
 # @param waittime                  Number of seconds to wait for PRRTE DVM to start before executing tests
+# @param checkpoint_file           Optional checkpoint file
 # @}
 class PRRTE(LauncherMTTTool):
 
@@ -74,6 +77,8 @@ class PRRTE(LauncherMTTTool):
         self.options['modules_swap'] = (None, "Modules to swap")
         self.options['dependencies'] = (None, "List of dependencies specified as the build stage name - e.g., MiddlwareBuild_package to be added to configure using --with-package=location")
         self.options['waittime'] = (5, "Number of seconds to wait for PRRTE DVM to start before executing tests")
+        self.options['checkpoint_file'] = (None, "Checkpoint file")
+        self.checkpoint_file=''
 
         self.allocated = False
         self.testDef = None
@@ -206,6 +211,9 @@ class PRRTE(LauncherMTTTool):
             for arg in optArgs:
                 cmdargs.append(arg.strip())
 
+        if cmds['checkpoint_file'] is not None:
+            self.checkpoint_file = cmds['checkpoint_file']
+
         # Allocate cluster
         status = self.allocateCluster(log, cmds, testDef)
         if 0 != status:
@@ -241,4 +249,9 @@ class PRRTE(LauncherMTTTool):
         # reset our paths and return us to our cwd
         self.resetPaths(log, testDef)
 
+        return
+
+    def savelog(self,testDef):
+        if self.checkpoint_file is not None:
+            testDef.logger.checkpointLog(self.checkpoint_file)
         return

--- a/pylib/Tools/Launcher/SLURM.py
+++ b/pylib/Tools/Launcher/SLURM.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; tab-width: 4; indent-tabs-mode: f; python-indent: 4 -*-
 #
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -41,6 +43,7 @@ import subprocess
 # @param allocate_cmd              Command to use for allocating nodes from the resource manager
 # @param deallocate_cmd            Command to use for deallocating nodes from the resource manager
 # @param dependencies              List of dependencies specified as the build stage name
+# @param checkpoint_file           Optional checkpoint file
 # @}
 class SLURM(LauncherMTTTool):
 
@@ -80,6 +83,8 @@ class SLURM(LauncherMTTTool):
         self.options['allocate_cmd'] = (None, "Command to use for allocating nodes from the resource manager")
         self.options['deallocate_cmd'] = (None, "Command to use for deallocating nodes from the resource manager")
         self.options['dependencies'] = (None, "List of dependencies specified as the build stage name - e.g., MiddlwareBuild_package to be added to configure using --with-package=location")
+        self.options['checkpoint_file'] = (None, "Checkpoint file")
+        self.checkpoint_file=''
 
         self.allocated = False
         self.testDef = None
@@ -175,6 +180,9 @@ class SLURM(LauncherMTTTool):
             cmdargs.append("-hostfile")
             cmdargs.append(cmds['hostfile'])
 
+        if cmds['checkpoint_file'] is not None:
+            self.checkpoint_file = cmds['checkpoint_file']
+
         # Allocate cluster
         status = self.allocateCluster(log, cmds, testDef)
         if 0 != status:
@@ -263,3 +271,10 @@ class SLURM(LauncherMTTTool):
 
 
         return
+
+    def savelog(self,testDef):
+        if self.checkpoint_file is not None:
+            testDef.logger.checkpointLog(self.checkpoint_file)
+        return
+
+

--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -3,7 +3,7 @@ from builtins import str
 #!/usr/bin/env python
 #
 # Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
-# Copyright (c) 2019      Triad National Security, LLC. All rights
+# Copyright (c) 2010-2021 Triad National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
 #
@@ -16,6 +16,8 @@ import sys
 import os
 import datetime
 from BaseMTTUtility import *
+import json
+import pickle
 
 ## @addtogroup Utilities
 # @{
@@ -205,3 +207,21 @@ class Logger(BaseMTTUtility):
                 pass
         # if we get here, then the key wasn't found
         return None
+
+
+    def checkpointLog(self, cpfile):
+        self.verbose_print("CHECKPOINTING LOG TO " + cpfile)
+        with open(cpfile + '.pkl', "wb") as f:
+            pickle.dump(self.results, f)
+        self.verbose_print("CHECKPOINTED LOG TO " + cpfile)
+
+    def restartLog(self, cpfile):
+        try:
+            self.verbose_print("READING LOG FROM " + cpfile)
+            fh = open(cpfile + '.pkl', 'rb')
+            self.results = pickle.load(fh)
+            fh.close()
+            self.outputLog()
+        except IOError:
+            print("Section " + result['section'] + " failed to open checkpoint file for reading", file=self.fh)
+            sys.stdout.flush()

--- a/samples/python/cpr_sample/get_build_ompi.ini
+++ b/samples/python/cpr_sample/get_build_ompi.ini
@@ -1,0 +1,54 @@
+[MTTDefaults]
+scratchdir = /users/XXX/mtt/scratch
+description = OpenMPI master
+platform = platform_foobar
+executor = sequential
+
+[Profile:Installed]
+
+#======================================================================
+# Middleware construction phases - get the middleware, build, and
+# install it. This isn't a required phase - if the purpose of this test
+# is to simply stress the physical system, then one can skip this phase
+#======================================================================
+
+[MiddlewareGet:OMPIMaster]
+plugin = OMPI_Snapshot
+url =  https://download.open-mpi.org/nightly/open-mpi/master
+version_file = /users/XXX/mtt/vf_master
+mpi_name = ompi-nightly-master
+
+#----------------------------------------------------------------------
+
+[MiddlewareBuild:OMPIMaster]
+parent = MiddlewareGet:OMPIMaster
+plugin = Autotools
+configure_options = --with-ofi
+make_options = -j 8
+checkpoint_file = /users/XXX/mtt/scratch/ompi_logfile_checkpoint
+
+#======================================================================
+# Test construction phases - get and build the tests that the
+# target software will run.
+#======================================================================
+
+[TestGet:IBM]
+plugin = Copytree
+src = /users/XXX/ompi-tests-for-mtt/ibm
+parent = MiddlewareBuild:OMPIMaster
+
+
+#======================================================================
+# Test build phase
+#======================================================================
+
+[TestBuild:IBMInstalled]
+parent = TestGet:IBM
+merge_stdout_stderr = 1
+stderr_save_lines = 100
+middleware = MiddlewareBuild:OMPIMaster
+autogen_cmd = ./autogen.sh
+configure_options = CC=mpicc CXX=mpic++ F77=mpif77 FC=mpifort
+make_options = -j 4
+checkpoint_file = /users/XXX/mtt/master_scratch/ompi_logfile_checkpoint
+

--- a/samples/python/cpr_sample/report_results.ini
+++ b/samples/python/cpr_sample/report_results.ini
@@ -1,0 +1,28 @@
+[MTTDefaults]
+scratchdir = /users/XXX/mtt/scratch
+description = OpenMPI master
+platform = foobar_platform
+executor = sequential
+restart_file = /users/XXX/mtt/scratch/ompi_logfile_checkpoint
+
+#======================================================================
+# Reporter phase
+#======================================================================
+
+[Reporter: text file backup]
+plugin = TextFile
+filename = mttresults.txt
+summary_footer =
+detail_header  =
+detail_footer  =
+textwrap = 78
+
+#----------------------------------------------------------------------
+
+[Reporter: IU database]
+plugin = IUDatabase
+realm = OMPI
+username = foobar
+pwfile = /users/XXX/mtt/pw_file
+platform = foobar_platform
+url = https://mtt.open-mpi.org/submit/cpy/api

--- a/samples/python/cpr_sample/run_mtt_backend.sh
+++ b/samples/python/cpr_sample/run_mtt_backend.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -l
+
+cd $HOME/mtt
+export MTT_HOME=$PWD
+pyclient/pymtt.py --verbose run_tests.ini
+

--- a/samples/python/cpr_sample/run_mtt_frontend.sh
+++ b/samples/python/cpr_sample/run_mtt_frontend.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+
+cd $HOME/mtt
+SCRATCH_FILE="scratch"
+SCRATCH_DIR=$HOME/mtt/$SCRATCH_FILE
+rm -f -r $SCRATCH_DIR
+export MTT_HOME=$PWD
+pyclient/pymtt.py --verbose  get_build_ompi.ini
+if [ $? -ne 0 ]
+then
+    echo "Something went wrong with fetch/build phase"
+    exit -1
+fi
+echo "============== Submitting batch job for Testing  ==============="
+jobid=`sbatch -o slurm.out --wait --parsable -N 4 --time=6:00:00 --tasks-per-node=8 ./run_mtt_backend.sh`
+if [ $jobid -eq 1 ]; then
+    echo "Something went wrong with batch job"
+    exit -1
+fi
+pyclient/pymtt.py --verbose  report_results.ini
+

--- a/samples/python/cpr_sample/run_tests.ini
+++ b/samples/python/cpr_sample/run_tests.ini
@@ -1,0 +1,48 @@
+# INI file for stretch
+
+[MTTDefaults]
+scratchdir = /users/XXX/mtt/master_scratch
+description = OpenMPI master
+platform = foobar_platform
+executor = sequential
+restart_file = /users/XXX/mtt/scratch/ompi_logfile_checkpoint
+
+[Profile:Installed]
+
+#======================================================================
+# Define some default launcher execution parameters
+#======================================================================
+
+[LauncherDefaults:OMPI]
+plugin = OpenMPI
+command = mpirun
+np = 32
+ppn = 8
+
+skipped = 77
+merge_stdout_stderr = 1
+stdout_save_lines = 100
+stderr_save_lines = 100
+
+#======================================================================
+# Test run phase - the executor will automatically change directory to
+# the top directory where the tests were installed, so any search for
+# executables will take place relative to that point
+#======================================================================
+
+[TestRun:IBMInstalledOMPI]
+plugin = OpenMPI
+parent = TestBuild:IBMInstalled
+timeout = 600
+test_dir = "collective, communicator, datatype, environment, group, info, io, pt2pt, random, topology"
+checkpoint_file = /users/XXX/mtt/scratch/ompi_logfile_checkpoint
+
+# Tests that are supposed to fail
+fail_tests = abort:3 final:1
+fail_timeout = max_procs
+
+# THREAD_MULTIPLE test will fail with the openib btl because it
+# deactivates itself in the presence of THREAD_MULTIPLE.  So just skip
+# it.  loop_child is the target for loop_spawn, so we don't need to
+# run it (although it'll safely pass if you run it by itself).
+skip_tests = init_thread_multiple comm_split_f


### PR DESCRIPTION
This feature adds support for checkpointing MTT logfiles as part of a MTT workflow
wherein some stages of an MTT workflow must be done on one set of system resources -
in particular login nodes to typical HPC DoE systems which have internet access -
but for other stages, such as running tests, MTT has to be run on backend nodes
with no internet access.

Pickle is used to serialize/deserialize the logfile irrespective of its structure.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>