### PR TITLE
Logger: convert list to str in a print statement

### DIFF
--- a/pylib/Utilities/Logger.py
+++ b/pylib/Utilities/Logger.py
@@ -3,6 +3,8 @@ from builtins import str
 #!/usr/bin/env python
 #
 # Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2019      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -179,7 +181,7 @@ class Logger(BaseMTTUtility):
                     sys.stdout.flush()
                     if 0 != result['status']:
                         try:
-                            print("    " + result['stderr'], file=self.fh)
+                            print("    " + str(result['stderr']), file=self.fh)
                             sys.stdout.flush()
                         except KeyError:
                             pass


### PR DESCRIPTION
If the test status section returns non-zero, pyclient throws this error:

=======================================
Exception was raised: <class 'TypeError'> must be str, not list
=======================================
Traceback (most recent call last):

  File "/users/hpp/mtt/pylib/Tools/Executor/sequential.py", line 286, in execute_sections
    plugin.execute(stageLog, keyvals, testDef)

  File "/users/hpp/mtt/pylib/Stages/MTTDefaults/DefaultMTTDefaults.py", line 116, in execute
    testDef.logger.restartLog(str(cmds['restart_file']))

  File "/users/hpp/mtt/pylib/Utilities/Logger.py", line 225, in restartLog
    self.outputLog()

  File "/users/hpp/mtt/pylib/Utilities/Logger.py", line 187, in outputLog
    print("    " + result['stderr'], file=self.fh)

TypeError: must be str, not list

This commit fixes this problem.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>