### PR TITLE
Added conditional execution using "run_if" option

### DIFF
--- a/docs/pages/user_guide.md
+++ b/docs/pages/user_guide.md
@@ -440,3 +440,59 @@ ${LOG:MTTDefaults.keys.3} = options
 ```
 
 In the above output, notice what looks like `{ ... }` and `[ ... ]`. These are simply where the LogInterpolationDebug plugin is hiding JSON strings that contain data that you can also access directly, and the form in which you access the data directly is also displayed in the debug output.
+
+### Skipping an INI section using "run_if"
+
+Sometimes you may only want part of your INI file to execute. This could be for modifying behavior based on the type of system being ran on, or also for running part of an INI file on one system and another part on a different system.
+
+To accomplish this behavior, MTT supports a special option for stages called "run_if". MTT will execute the shell command specified by "run_if" and if the return code is nonzero then that section is skipped.
+
+For example, these sections will not be executed:
+
+```
+[TestRun:no_execute_1]
+plugin = Shell
+run_if = sh -c 'exit 1'
+command = echo 'hello'
+
+[TestRun:no_execute_2]
+plugin = Shell
+run_if = false
+command = echo 'hello'
+```
+
+Whereas these sections will be executed:
+
+```
+[TestRun:yes_execute_1]
+plugin = Shell
+command = echo 'hello'
+
+[TestRun:yes_execute_2]
+plugin = Shell
+run_if = sh -c 'exit 0'
+command = echo 'hello'
+
+[TestRun:yes_execute_3]
+plugin = Shell
+run_if = true
+command = echo 'hello'
+```
+
+You can use an environment variable with run_if like so:
+
+```
+[TestRun:some_stage]
+plugin = Shell
+run_if = test $$SOME_VARIABLE == "some value"
+command = echo 'hello'
+```
+
+You can also check if a file exists with run_if like so:
+
+```
+[TestRun:some_stage]
+plugin = Shell
+run_if = test -f /tmp/some_file.txt
+command = echo 'hello'
+```

--- a/tests/bat/run_if.ini
+++ b/tests/bat/run_if.ini
@@ -1,0 +1,66 @@
+#Copyright (c) 2021 Intel, Inc.  All rights reserved.
+#
+
+# Set defaults
+[MTTDefaults]
+scratch = mttscratch
+description = Testing run_if option
+
+[TestGet:get_script]
+plugin = Copy
+src = ${ENV:MTT_HOME}/tests/bat/run_if.sh
+
+[TestRun:yes_execute]
+plugin = Shell
+run_if = true
+command = sh -c 'echo "this should execute"; exit 0'
+
+[TestRun:no_execute]
+plugin = Shell
+run_if = false
+command = sh -c 'echo "this should not execute"; exit 1'
+
+[TestRun:no_execute_positive]
+plugin = Shell
+run_if = sh -c 'echo "returning 2"; exit 2'
+command = sh -c 'echo "this should not execute"; exit 1'
+
+[TestRun:no_execute_negative]
+plugin = Shell
+run_if = sh -c 'echo "returning -2"; exit -2'
+command = sh -c 'echo "this should not execute"; exit 1'
+
+[TestRun:no_execute_empty_runif]
+plugin = Shell
+run_if =
+command = sh -c 'echo "this should not execute"; exit 1'
+
+[TestRun:yes_execute_no_runif]
+plugin = Shell
+command = sh -c 'echo "this should execute"; exit 0'
+
+[TestRun:yes_execute_test_script]
+plugin = Shell
+parent = TestGet:get_script
+run_if = ./run_if.sh 0
+command = sh -c 'echo "this should execute"; exit 0'
+
+[TestRun:no_execute_test_script]
+plugin = Shell
+parent = TestGet:get_script
+run_if = ./run_if.sh 1
+command = sh -c 'echo "this should not execute"; exit 1'
+
+
+#======================================================================
+# Reporter phase
+#======================================================================
+[Reporter:TextFileConsole]
+plugin = TextFile
+
+#======================================================================
+# Reporter phase
+#======================================================================
+[Reporter:JunitXML]
+plugin = JunitXML
+filename = run_if.xml

--- a/tests/bat/run_if.sh
+++ b/tests/bat/run_if.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "returning $1"
+exit $1


### PR DESCRIPTION
run_if holds a shell command to execute. This can be `sh -c 'exit 1'`, `false`, `true`, `./run_script.sh`, or any shell command.

To run the example ini file and test out this change, do this:

```
export MTT_HOME=/path/to/mtt
$MTT_HOME/pyclient/pymtt.py --verbose $MTT_HOME/tests/bat/run_if.ini
```

The usage looks like

```
[TestRun:yes_execute]
plugin = Shell
run_if = true
command = sh -c 'echo "this should execute"; exit 0'

[TestRun:no_execute]
plugin = Shell
run_if = false
command = sh -c 'echo "this should not execute"; exit 1'
```


The output looks like

```
===========================================================================
START EXECUTING [TestRun:yes_execute] start_time=2021-07-16 13:40:00.601053
===========================================================================
OPTIONS FOR SECTION: TestRun:yes_execute
   plugin = Shell
   run_if = true
  command = sh -c 'echo "this should execute"; exit 0'
run_if command: true
ExecuteCmd start: true
ExecuteCmd done
run_if result: 0 - running section
Executing plugin Shell
Using resource manager: slurm
Shell Execute
ExecuteCmd start: icc -c spastic.c
ExecuteCmd done
ExecuteCmd start: icc --version
stdout: icc (ICC) 2021.1 Beta 20200827
stdout: Copyright (C) 1985-2020 Intel Corporation.  All rights reserved.
stdout: 
ExecuteCmd done
ExecuteCmd start: sh -c echo this should execute; exit 0
stdout: this should execute
ExecuteCmd done
DONE EXECUTING [TestRun:yes_execute] end_time=2021-07-16 13:40:00.710968, elapsed=0:00:00.109915
STATUS OF [TestRun:yes_execute] IS 0

LOGGING results for TestRun:yes_execute
TestRun:no_execute

==========================================================================
START EXECUTING [TestRun:no_execute] start_time=2021-07-16 13:40:00.711448
==========================================================================
OPTIONS FOR SECTION: TestRun:no_execute
   plugin = Shell
   run_if = false
  command = sh -c 'echo "this should not execute"; exit 1'
run_if command: false
ExecuteCmd start: false
ExecuteCmd done
run_if result: 1 - skipping section
TestRun:no_execute_positive
```