### PR TITLE
Fix `trial` INI option of `MTTDefaults` stage always being ignored

### DIFF
--- a/pyclient/pymtt.py
+++ b/pyclient/pymtt.py
@@ -146,7 +146,7 @@ debugGroup.add_argument("--dryrun",
                       action="store_true", dest="dryrun", default=False,
                       help="Show commands, but do not execute them")
 debugGroup.add_argument("--trial",
-                      action="store_true", dest="trial", default=False,
+                      action="store_true", dest="trial", default=None,
                       help="Use when testing your MTT client setup; results that are generated and submitted to the database are marked as \"trials\" and are not included in normal reporting.")
 
 elkGroup = parser.add_argument_group('elkGroup','ELK-friendly output options')


### PR DESCRIPTION
The doc pages and Github-io page explain the `trial` flag as [a parameter of the `MTTDefaults` stage](https://open-mpi.github.io/mtt/pages/user_guide.html#ini-section-mttdefaults).

<details><summary>However, whatever is specified in that location is ignored (example).</summary>

Minimal example .ini file `./minimal_trial.ini`:
```ini
[MTTDefaults]
trial = True

[Reporter: console]
plugin = TextFile
```
Program output of `python pyclient/pymtt.py ./minimal_trial.ini`:
```
../mtt/pyclient/pymtt.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
Section: MTTDefaults Status: 0
        Input parameters:
                 trial = True
                 executor = sequential
        Final options:
                 trial = False
                 scratchdir = /home/thesis/hoermann/mtt-tests/scripts/mttscratch
                 description = None
                 platform = None
                 organization = None
                 merge_stdout_stderr = False
                 stdout_save_lines = -1
                 stderr_save_lines = -1
                 executor = sequential
                 time = False
                 restart_file = None

Num sections pass: 1 / 1 sections
Percentage sections pass: 100.0
```
</details>

I assume that isn't the intended behaviour. I found out it happens because the command-line flag `--trial` is registered with default value `False` in [`pyclient/pymtt.py:148`](https://github.com/open-mpi/mtt/blob/02bdcab2d797553cdfd2f944e828f226cea81423/pyclient/pymtt.py#L148).
Because these parsed options are applied onto the `testDef` instance via the [call to `setOptions` in line 260](https://github.com/open-mpi/mtt/blob/02bdcab2d797553cdfd2f944e828f226cea81423/pyclient/pymtt.py#L260), the option is always set to `True` or `False`, which overrides all further configuration from `.ini`-files.

Specifying `None` as the default value, as in this PR, fixes this, so that the option priority becomes CLI -> `.ini` configuration -> `False` fallback.