### PR TITLE
sql workaround - replace 0x00 with stuff

### DIFF
--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -478,9 +478,11 @@ class IUDatabase(ReporterMTTStage):
 
             try:
                 if type(trun['stderr']) is list:
-                    data['result_stderr'] = '\n'.join(trun['stderr'] if trun['stderr'] is not None else "")
+                    result_stderr_str = '\n'.join(trun['stderr'] if trun['stderr'] is not None else "")
+                    data['result_stderr'] = result_stderr_str.replace("\x00", "\uFFFD")
                 else:
-                    data['result_stderr'] = (trun['stderr'] if trun['stderr'] is not None else "")
+                    result_stderr_str = (trun['stderr'] if trun['stderr'] is not None else "")
+                    data['result_stderr'] = result_stderr_str.replace("\x00", "\uFFFD")
             except KeyError:
                 data['result_stderr'] = None
 


### PR DESCRIPTION
a workaround to avoid problem described at

https://stackoverflow.com/questions/57371164/django-postgres-a-string-literal-cannot-contain-nul-0x00-characters

when using the IU database reporter mechanism

Signed-off-by: Howard Pritchard <howardp@lanl.gov>