### PR TITLE
iudatabase:  minor code cleanup

### DIFF
--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -496,7 +496,7 @@ class IUDatabase(ReporterMTTStage):
             data = self._submit_json_data(payload, s, url, httpauth)
             if data is None:
                 return None
-            if data['status'] is not 0:
+            if data['status'] != 0:
                 return None
 
         return True
@@ -652,7 +652,7 @@ class IUDatabase(ReporterMTTStage):
         data = self._submit_json_data(payload, s, url, httpauth)
         if data is None:
             return None
-        if data['status'] is not 0:
+        if data['status'] != 0:
             return None
 
         # Extract ID
@@ -851,7 +851,7 @@ class IUDatabase(ReporterMTTStage):
         data = self._submit_json_data(payload, s, url, httpauth)
         if data is None:
             return None
-        if data['status'] is not 0:
+        if data['status'] != 0:
             return None
 
         # Extract ID
@@ -922,7 +922,7 @@ class IUDatabase(ReporterMTTStage):
         if data is None:
             return -1
 
-        if data['status'] is not 0:
+        if data['status'] != 0:
             return -2
 
         return data['client_serial']


### PR DESCRIPTION
newer versions of python were warning about syntax errors in
IUDatabase.py

pylib/Stages/Reporter/IUDatabase.py:499: SyntaxWarning: "is not" with a literal. Did you mean "!="?

This patch makes these versions (3.8 and greater?) of python much happier.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>