### PR TITLE
Fix usage of 'exec' key in AlreadyInstalled plugin

### DIFF
--- a/pylib/Tools/Fetch/AlreadyInstalled.py
+++ b/pylib/Tools/Fetch/AlreadyInstalled.py
@@ -61,6 +61,10 @@ class AlreadyInstalled(FetchMTTTool):
         # parse any provided options - these will override the defaults
         cmds = {}
         testDef.parseOptions(log, self.options, keyvals, cmds)
+
+        if cmds['exec'] is None:
+            log['status'] = 0
+            return
   
         # Apply any requested environment module settings
         status,stdout,stderr = testDef.modcmd.applyModules(log['section'], cmds, testDef)
@@ -71,7 +75,7 @@ class AlreadyInstalled(FetchMTTTool):
             return
 
         # now look for the executable in our path
-        if not find_executable(keyvals['exec']):
+        if not find_executable(cmds['exec']):
             log['status'] = 1
             log['stderr'] = "Executable " + cmds['exec'] + " not found"
         else:


### PR DESCRIPTION
The check trying to find the `exec` used the wrong dictionary (`keyval` instead of `cmds`) and didn't check for whether `exec` was set in the first place.

At a larger scale, the documentation [1] does not mention `exec` (or the `module_unload` key) and it's not clear to me what that check is actually for. Isn't it sufficient to check whether `command` specified in `LauncherDefaults` is available?

[1] https://open-mpi.github.io/mtt/pages/user_guide.html#ini-section-middlewareget

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>