### PR TITLE
Combinatorial: warn if TestRun or MiddlewareGet sections are missing

### DIFF
--- a/pylib/Tools/Executor/combinatorial.py
+++ b/pylib/Tools/Executor/combinatorial.py
@@ -95,6 +95,10 @@ class CombinatorialEx(ExecutorMTTTool):
             else:
                 self.iniLog[section] = fileName
         # Combine TestRun and MiddlewareGet files
+        if len(self.runLog) == 0 or len(tempSpecialSection) == 0:
+            print("Error: Missing required 'MiddlewareGet' or 'TestRun' section in config file")
+            sys.exit(1)
+
         tempList = {}
         for section in self.runLog:
             self.parser.read(self.runLog[section])


### PR DESCRIPTION
The Combinatorial executor would fail with a cryptic error saying that no run log is available. Be a little nicer and at least say what's missing...

Addresses https://github.com/open-mpi/mtt/issues/891 (not sure it's a real fix, just playing a little nicer)

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>