### PR TITLE
Add --enable-mpirun-prefix-by-default to sample config

### DIFF
--- a/samples/python/ompi_snapshot_seq.ini
+++ b/samples/python/ompi_snapshot_seq.ini
@@ -38,7 +38,7 @@ mpi_name = ompi-nightly-main
 [MiddlewareBuild:OMPIMaster]
 parent = MiddlewareGet:OMPIMaster
 plugin = Autotools
-configure_options = --enable-debug  --enable-mpi1-compatibility
+configure_options = --enable-debug  --enable-mpi1-compatibility --enable-mpirun-prefix-by-default
 make_options = -j 1
 
 #======================================================================


### PR DESCRIPTION
Prevents test failures caused by ORTE not setting the prefix correctly

Signed-off-by: Sai Sunku <sunkusa@amazon.com>