### PR TITLE
Changes from Open MPI AWS server

### DIFF
--- a/server/php/cherrypy/bin/mtt_server_service.py
+++ b/server/php/cherrypy/bin/mtt_server_service.py
@@ -1,4 +1,4 @@
-#!src/env/bin/python
+#!/usr/bin/env python
 """
 Control the MTT REST server.
 

--- a/server/php/cherrypy/src/MTTServer.py
+++ b/server/php/cherrypy/src/MTTServer.py
@@ -60,7 +60,8 @@ if __name__ == '__main__':
     conf = {
         'global': {
             'server.socket_host': socket.gethostbyname(socket.gethostname()),
-            'log.access_file': '../log/access.log',
+            'log.access_file': '',
+            #'log.access_file': '../log/access.log',
             'log.error_file': '../log/cherrypy_error.log',
             'log.screen': False,
             # Autoreload is very useful when debugging or updating frequently

--- a/server/php/cherrypy/src/webapp/db_pgv3.py
+++ b/server/php/cherrypy/src/webapp/db_pgv3.py
@@ -302,7 +302,15 @@ class DatabaseV3():
 
     def get_cursor(self):
         # Don't forget to: _cursor.close()
-        return self._connection.cursor()
+#       if (self._connection.closed == 1)
+#           self.connect()
+        try:
+            cursor = self._connection.cursor()
+        except Exception as ex:
+            self._logger.debug("get cursor: got exception %s" % str(ex))
+            self.connect()
+            cursor = self._connection.cursor()
+        return cursor
 
     def disconnect(self):
         self._connection.commit()
@@ -609,6 +617,7 @@ class DatabaseV3():
         cursor = self.get_cursor()
 
         values = tuple(insert_stmt_values)
+#       values = values.replace("\x00", "\uFFFD")
         cursor.execute( select_stmt, values )
         rows = cursor.fetchone()
         if rows is not None:
@@ -626,6 +635,7 @@ class DatabaseV3():
 
         insert_stmt_values.insert(0, found_id)
         values = tuple(insert_stmt_values)
+#       values = values.replace("\x00", "\uFFFD")
         cursor.execute( insert_stmt, values )
         # Make sure to commit after every INSERT
         self._connection.commit()

--- a/server/php/cherrypy/src/webapp/dispatchers.py
+++ b/server/php/cherrypy/src/webapp/dispatchers.py
@@ -108,9 +108,11 @@ class _ServerResourceBase:
 
     def _extract_http_username(self, auth):
         tmp = auth
+        self.logger.debug("tmp =  %s" % str(tmp))
         try:
             tmp = base64.b64decode(tmp[6:len(tmp)])
-            return tmp.split(':')[0]
+            tmp_c = tmp.decode("utf-8")
+            return tmp_c.split(':')[0]
         except:
             return "(unknown)"
 
@@ -260,7 +262,7 @@ class Submit(_ServerResourceBase):
     @cherrypy.tools.json_out()
     def GET(self, **kwargs):
         prefix = 'Root [GET /submit/]'
-        self.logger.debug(prefix)
+        self.logger.info(prefix)
 
         rtn = {}
         rtn['status'] = 0
@@ -275,7 +277,7 @@ class Submit(_ServerResourceBase):
     @cherrypy.tools.json_in()
     def POST(self, **kwargs):
         prefix = 'Submit [POST /submit/]'
-        self.logger.debug(prefix)
+        self.logger.info(prefix)
 
         if not hasattr(cherrypy.request, "json"):
             self.logger.error(prefix + " No json data sent")
@@ -294,7 +296,7 @@ class Submit(_ServerResourceBase):
         self.logger.debug( "----------------------- All Data JSON (End  ) ------------------ " )
 
         data['metadata']['http_username'] = self._extract_http_username(cherrypy.request.headers['Authorization'])
-        self.logger.debug(prefix + " Append to metadata 'http_username' = '" + data['metadata']['http_username'] + "'")
+        self.logger.info(prefix + " Append to metadata 'http_username' = '" + data['metadata']['http_username'] + "'")
         
         #
         # Make sure we have all the metadata we need
@@ -310,7 +312,7 @@ class Submit(_ServerResourceBase):
         if phase == self._phase_unknown:
             return self._return_error(prefix, -1, "%s An unknown phase (%s) was specified in the metadata" % (prefix, data["metadata"]["phase"]))
 
-        self.logger.debug( "Phase: %2d = [%s]" % (phase, data["metadata"]['phase']) )
+        self.logger.info( "Phase: %2d = [%s]" % (phase, data["metadata"]['phase']) )
 
         if 'data' not in data.keys():
             self.logger.error(prefix + " No 'data' array in json data")


### PR DESCRIPTION
 * Use `env` to get the `python` library
 * Disable the `access.log` file. It doesn't provide any useful information.
 * Make `get_cursor` function more robust
 * Handle some UTF-8 characters
 * Adjust a few log messages from `debug` to `info`

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>