### PR TITLE
Clone a separate repo for each TestGet section

### DIFF
--- a/pylib/Tools/Fetch/Git.py
+++ b/pylib/Tools/Fetch/Git.py
@@ -148,6 +148,9 @@ class Git(FetchMTTTool):
         if repo.endswith(".git"):
             repo = repo[0:len(repo)-4]
 
+        dst = os.path.join(testDef.options['scratchdir'], log['section'].replace(":","_"))
+        repo = os.path.join(dst, repo)
+
         # Apply any requested environment module settings
         status,stdout,stderr = testDef.modcmd.applyModules(log['section'], cmds, testDef)
         if 0 != status:
@@ -245,7 +248,6 @@ class Git(FetchMTTTool):
         # record our current location
         cwd = os.getcwd()
 
-        dst = os.path.join(testDef.options['scratchdir'], log['section'].replace(":","_"))
         try:
             if not os.path.exists(dst): os.mkdir(dst)
         except:


### PR DESCRIPTION
This change alters the git clone behavior for TestGet sections.

Currently, if TestGet:XXX and TestGet:YYY section requires the same git repository, the repo is only cloned once, which is unlikely the desired behavior.

With this change, each TestGet section will have a separate clone of the repo. This prevents dependent TestRun conflicts.