### PR TITLE
LauncherMTTTool.py: reset test list in each collectTests run

### DIFF
--- a/pylib/Tools/Launcher/LauncherMTTTool.py
+++ b/pylib/Tools/Launcher/LauncherMTTTool.py
@@ -218,7 +218,13 @@ class LauncherMTTTool(IPlugin):
         os.chdir(self.cwd)
         return
 
+    def resetTests(self):
+        self.tests = []
+        self.skip_tests = []
+        self.expected_returncodes = {}
+
     def collectTests(self, log, cmds):
+        self.resetTests()
         # did they give us a list of specific directories where the desired
         # tests to be executed reside?
         if cmds['test_list'] is None:


### PR DESCRIPTION
The current launcher plugin initialize a singleton instance, e.g. OpenMPI for mulitple TestRun sections. The test list is therefore reused and appended to. This results in monotonic growth, causing subsequent TestRun sections to inadvertently inherit tests selected by prior sections.

In the following example, TestRun:IntelInstalled will run tests in both ibm/random and intel-tests/src folders.

```
[TestRun:IBMInstalledOMPI]
parent = TestBuild:IBMInstalled
test_dir = "random"
fail_tests = abort:3 final:14
plugin = OpenMPI

[TestRun:IntelInstalled]
parent = TestBuild:IntelInstalled
test_dir = "src"
plugin = OpenMPI
```

This patch resets the test list for each collecTests call, such that each section only runs tests selected in that section alone.