### PR TITLE
fix problem with malformed new lines

### DIFF
--- a/server/php/cron/alerts.php
+++ b/server/php/cron/alerts.php
@@ -59,12 +59,14 @@ print "\nCreating reports specified in $ini_file.";
 # Reference:
 #   http://www.zend.com/zend/trick/html-email.php
 
+
+
 $headers  = "From: mtt-results@lists.open-mpi.org\r\n";
 $headers .= "MIME-Version: 1.0\r\n";
 $boundary = uniqid("MTTREPORT");
 $headers .= "Content-Type: multipart/alternative" .
-            "; boundary = $boundary\r\n\r\n";
-$headers .= "This is a MIME encoded message.\r\n\r\n";
+            "; boundary = $boundary\r\n";
+$headers .= "This is a MIME encoded message.\r\n";
 # $headers .= "--$boundary\r\n" .
 #             "Content-Type: text/plain; charset=ISO-8859-1\r\n" .
 #             "Content-Transfer-Encoding: base64\r\n\r\n";
@@ -99,7 +101,7 @@ foreach (array_keys($ini) as $section) {
     # if we can not find it - send the email
     elseif (! contains_null_result_msg($html)) {
         $report = chunk_split(base64_encode($html));
-        mail($email, $section, '', $headers . $report);
+ 	mail($email, $section, $report, $headers);
     }
     # Do not email a blank report
     else {

--- a/server/php/cron/morning.ini
+++ b/server/php/cron/morning.ini
@@ -3,7 +3,7 @@
 ;
 
 [Morning MTT Results Summary]
-url="https://mtt.open-mpi.org/index.php?&text_start_timestamp=past+12+hours&show_start_timestamp=show&text_http_username=all&show_http_username=show&text_local_username=all&show_local_username=hide&text_platform_name=all&show_platform_name=show&text_platform_hardware=all&show_platform_hardware=show&text_os_name=all&show_os_name=show&text_mpi_name=all&show_mpi_name=show&text_mpi_version=all&show_mpi_version=show&go=summary&click=summary&phase=all_phases&text_trial="
+url="https://mtt.open-mpi.org/index.php?&text_start_timestamp=past+24+hours&show_start_timestamp=show&text_http_username=all&show_http_username=show&text_local_username=all&show_local_username=hide&text_platform_name=all&show_platform_name=show&text_platform_hardware=all&show_platform_hardware=show&text_os_name=all&show_os_name=show&text_mpi_name=all&show_mpi_name=show&text_mpi_version=all&show_mpi_version=show&go=summary&click=summary&phase=all_phases&text_trial="
 email = "mtt-results@lists.open-mpi.org"
 
 ; [Morning MPI Install Failures]


### PR DESCRIPTION
in the alerts.php script.

Looks like when we moved to AWS we hit a variant of this issue

https://stackoverflow.com/questions/30887610/error-with-php-mail-multiple-or-malformed-newlines-found-in-additional-header

and the script for nightly MTT results was never changed till now to fix this.

Also up to 24 hours results reported for the morning cron job.