### PR TITLE
reporter: quick fixes for php8

### DIFF
--- a/server/php/reporter/dashboard.inc
+++ b/server/php/reporter/dashboard.inc
@@ -270,7 +270,7 @@ function get_form_universe2($sql_cmd, $resource) {
         foreach (array_keys($hash[$i]) as $k)
             $arr[$k][] = $hash[$i][$k];
 
-    foreach (array_keys($arr) as $k)
+    foreach (array_keys((array)$arr) as $k)
         # Do not collect timestamp entries from the ttable
         if (! preg_match("/timestamp/", $k))
             $entries[$k][] = array_unique($arr[$k]);
@@ -862,7 +862,10 @@ function selection_popups($defaults, $entries) {
             "\n</div>";
 
         # Widen popup according to the number of menus
-        $num_menus = sizeof($entries[$field]);
+	$num_menus = 0;
+        if (! is_null($entries)) {
+            $num_menus = sizeof((array)$entries[$field]);
+	}
 
         # Yippee, selection popup
         if ($linkto) {
@@ -961,7 +964,7 @@ function form_popup($elements, $params, $specs) {
     $max = 0;
     foreach (array_keys($elements) as $category) {
         foreach (array_keys($elements[$category]) as $field) {
-            $size = sizeof($elements[$category][$field]);
+            $size = sizeof((array)$elements[$category][$field]);
             if ($size > $max)
                 $max = $size;
         }

--- a/server/php/reporter/db_iface.inc
+++ b/server/php/reporter/db_iface.inc
@@ -435,9 +435,9 @@ function INTERNAL_db_iface_compose_sql_summary_all_fast($query) {
     #
     $groupbys = array_unique(
         array_merge(
-	     (array)array_keys($query['select']),
-	     (array)array_keys($query['select_more']),
-	     (array)array_keys($query['performance'])
+	     (array)array_keys((array)$query['select']),
+	     (array)array_keys((array)$query['select_more']),
+	     (array)array_keys((array)$query['performance'])
         )
     );
 
@@ -557,8 +557,8 @@ function INTERNAL_db_iface_compose_sql_summary_fast_sub_table_base($query, $sele
     #
     $sql_cmd .= "WHERE ".$nltt;
     # Filter the array in case there are NULLs
-    $sql_cmd .= join(" AND $nltt", array_filter(array_values2($query['where'])));
-    $sql_cmd .= join(" AND $nltt", array_filter(array_values2($query['where_not'])));
+    $sql_cmd .= join(" AND $nltt", array_filter((array)array_values2($query['where'])));
+    $sql_cmd .= join(" AND $nltt", array_filter((array)array_values2($query['where_not'])));
 
     return $sql_cmd;
 }
@@ -1457,7 +1457,7 @@ function is_result_column($str) {
 # Return the array values that are a depth of 
 # 2 away from the argument passed
 function array_values2($arr) {
-    foreach (array_keys($arr) as $k)
+    foreach (array_keys((array)$arr) as $k)
         $ret[] = $arr[$k];
 
     return $ret;

--- a/server/php/reporter/main_reporter.inc
+++ b/server/php/reporter/main_reporter.inc
@@ -135,10 +135,10 @@ function display_report() {
         $o = offset($_GET);
 
         # Prepare headers array for *_table functions
-        $headers['params']      = array_keys($query['select']);
-        $headers['details']     = array_keys($query['select_more']);
-        $headers['performance'] = array_keys($query['performance']);
-        $headers['results']     = array_keys($query['aggregates']);
+        $headers['params']      = array_keys((array)$query['select']);
+        $headers['details']     = array_keys((array)$query['select_more']);
+        $headers['performance'] = array_keys((array)$query['performance']);
+        $headers['results']     = array_keys((array)$query['aggregates']);
         $headers['phases']      = $phases;
         $headers['offset']      = $o;
     }
@@ -2000,7 +2000,7 @@ function is_cherry_pick($params) {
 
 # Mutator function to clear out all cherry checkbox values
 function unset_cherries(&$arr) {
-    foreach (array_keys($arr) as $k)
+    foreach (array_keys((array)$arr) as $k)
         if (preg_match("/cherry_\d+/i", $k))
             unset($arr[$k]);
 }

--- a/server/php/reporter/reporter.inc
+++ b/server/php/reporter/reporter.inc
@@ -914,9 +914,9 @@ function tokenize($string) {
          $next_token !== false;
          $next_token = strtok(' ')) {
 
-        if ($next_token{0} == '"')
+        if ($next_token[0] == '"')
             $next_token =
-                $next_token{strlen($next_token) - 1} == '"' ?
+                $next_token[strlen($next_token) - 1] == '"' ?
                      substr($next_token, 1, -1) :
                      substr($next_token, 1) . ' ' . strtok('"');
         $tokens[] = $next_token;


### PR DESCRIPTION
Upgrading the mtt server to Ubuntu 24 broke some of the old php7 style code used in the mtt reporter.

A complete audit of the code needs to be done at some point to convert from php7 to php8.

This is the minimum needed to get the mtt reporter functioning.