### PR TITLE
Fixed hostname retrieval when filling JSON metadata

### DIFF
--- a/pylib/Stages/Reporter/IUDatabase.py
+++ b/pylib/Stages/Reporter/IUDatabase.py
@@ -141,11 +141,10 @@ class IUDatabase(ReporterMTTStage):
 
         data = {}
 
-        profile = testDef.logger.getLog('Profile:Installed')
         metadata = {}
         if not self.cmds['dryrun']:
             metadata['client_serial'] = client_serial
-        metadata['hostname'] = "\n".join(profile['profile']['nodeName'])
+        metadata['hostname'] = self._extract_param(testDef.logger, 'Profile:Installed','nodeName')
         metadata['http_username'] = self.cmds['username']
         metadata['local_username'] = pwd.getpwuid(os.getuid()).pw_name
         metadata['mtt_client_version'] = '4.0a1'


### PR DESCRIPTION
Profile options are stored in 'parameter' entry, not in 'profile'