### PR TITLE
SQL: update annual maintance README

### DIFF
--- a/server/sql/support/README
+++ b/server/sql/support/README
@@ -1,5 +1,7 @@
 How to add new yearly tables to the PostgreSQL database.
 
+Note on the OMPI AWS MTT instance we use an alias to psql named psql-ompi.
+
 1) Verify that the tables have not already been added to the database:
  -------------------
  shell$ psql mtt


### PR DESCRIPTION
with useful note about the alias used on the AWS MTT instance for psql.